### PR TITLE
fix alignment

### DIFF
--- a/period_search_opencl_amd/period_search/Start_OpenCl.cpp
+++ b/period_search_opencl_amd/period_search/Start_OpenCl.cpp
@@ -1032,7 +1032,7 @@ cl_int ClPrecalc(cl_double freq_start, cl_double freq_end, cl_double freq_step, 
     // 18-SEP-2023
     //size_t pccSize = CUDA_grid_dim_precalc * sizeof(mfreq_context);
     //auto pcc = new mfreq_context[CUDA_grid_dim_precalc];
-    auto pccSize = ((sizeof(mfreq_context) * CUDA_grid_dim_precalc - 1) / 64 + 1) * 64;
+    auto pccSize = ((sizeof(mfreq_context) * CUDA_grid_dim_precalc) / 128 + 1) * 128;
     auto pcc = (mfreq_context*)_aligned_malloc(pccSize, 128);
 #elif NVIDIA
     int pccSize = CUDA_grid_dim_precalc * sizeof(mfreq_context);

--- a/period_search_opencl_amd/period_search/Start_OpenCl.cpp
+++ b/period_search_opencl_amd/period_search/Start_OpenCl.cpp
@@ -116,7 +116,7 @@ cl_uint faOptimizedSize = ((sizeof(freq_context) - 1) / 64 + 1) * 64;
 auto Fa = (freq_context*)aligned_alloc(4096, faOptimizedSize);
 #else
 // freq_context* Fa; // __attribute__((aligned(8)));
-cl_uint faSize = ((sizeof(freq_context) - 1) / 64 + 1) * 64;
+cl_uint faSize = (sizeof(freq_context) / 128 + 1) * 128;
 auto Fa = (freq_context*)aligned_alloc(128, faSize);
 // freq_context* Fa __attribute__((aligned(8))) = static_cast<freq_context*>(malloc(sizeof(freq_context)));
 #endif
@@ -1006,7 +1006,7 @@ cl_int ClPrecalc(cl_double freq_start, cl_double freq_end, cl_double freq_step, 
     
     // cl_uint pccSize = CUDA_grid_dim_precalc * sizeof(mfreq_context);
     // auto pcc = new mfreq_context[CUDA_grid_dim_precalc];
-    auto pccSize = ((sizeof(mfreq_context) * CUDA_grid_dim_precalc - 1) / 64 + 1) * 64;
+    auto pccSize = ((sizeof(mfreq_context) * CUDA_grid_dim_precalc) / 128 + 1) * 128;
     auto pcc = (mfreq_context*)aligned_alloc(128, pccSize);
 
     // auto pcc = queue.enqueueMapBuffer(CUDA_MCC2, CL_BLOCKING, CL_MAP_READ | CL_MAP_WRITE, 0, pccSize, NULL, NULL, err);
@@ -1203,7 +1203,7 @@ cl_int ClPrecalc(cl_double freq_start, cl_double freq_end, cl_double freq_step, 
     // auto memFr = (freq_result *)aligned_alloc(128, frSize);
     // auto memFr = new (freq_result *)aligned_alloc(128, frSize);
     // auto CUDA_FR = cl::Buffer(context, CL_MEM_READ_WRITE | CL_MEM_USE_HOST_PTR,  frSize, memFr, err);
-    cl_uint frSize = sizeof(freq_result) * CUDA_grid_dim_precalc;
+    cl_uint frSize = (sizeof(freq_result) * CUDA_grid_dim_precalc / 128 + 1) * 128;
     // auto pfr = new freq_result[CUDA_grid_dim_precalc];
     auto pfr = (freq_result*)aligned_alloc(128, frSize);
     cl_mem CUDA_FR = clCreateBuffer(context, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR, frSize, pfr, &err);


### PR DESCRIPTION
using CFLAGS -fsanitize=address -fno-omit-frame-pointer

```
==9074==ERROR: AddressSanitizer: invalid alignment requested in aligned_alloc: 128, alignment must be a power of two and the requested size 0x42f4c1 must be a multiple of alignment (thread T0)
    #0 0x55b24ef525d8 in aligned_alloc (/usr/lib64/libasan.so.8+0x1525d8) (BuildId: 1dd6ab71650b77b74c6f251ed9e55e8b12f54ffa)
    #1 0x55b24f696a8b in __static_initialization_and_destruction_0 /PeriodSearch/period_search_opencl_amd/period_search/Start_OpenCl.cpp:123
    #2 0x55b24f696ad6 in _GLOBAL__sub_I_err /PeriodSearch/period_search_opencl_amd/period_search/Start_OpenCl.cpp:2372
    #3 0x55b24e62a0b5 in call_init ../csu/libc-start.c:145
    #4 0x55b24e62a0b5 in __libc_start_main_impl ../csu/libc-start.c:347

==9074==HINT: if you don't care about these errors you may set allocator_may_return_null=1
SUMMARY: AddressSanitizer: invalid-aligned-alloc-alignment (/usr/lib64/libasan.so.8+0x1525d8) (BuildId: 1dd6ab71650b77b74c6f251ed9e55e8b12f54ffa) in aligned_alloc
==9074==ABORTING
```

https://en.cppreference.com/w/c/memory/aligned_alloc
number of bytes to allocate. An integral multiple of alignment