### PR TITLE
m_pi fallback

### DIFF
--- a/period_search_opencl_amd/period_search/constants.h
+++ b/period_search_opencl_amd/period_search/constants.h
@@ -1,3 +1,7 @@
+#ifndef M_PI
+  #define M_PI 3.14159265358979323846
+#endif
+
 #define POINTS_MAX         2000             /* max number of data points in one lc. */
 #define MAX_N_OBS         20000             /* max number of data points */
 #define MAX_LC              200             /* max number of lightcurves */


### PR DESCRIPTION
use a fallback for compilers that don't define M_PI with -std=c++17

https://stackoverflow.com/questions/26065359/m-pi-flagged-as-undeclared-identifier