### PR TITLE
bulldozer optimization

### DIFF
--- a/period_search_optimization_simd/period_search/CpuInfo.cpp
+++ b/period_search_optimization_simd/period_search/CpuInfo.cpp
@@ -147,9 +147,9 @@ static bool IsBulldozer()
 
 	GetCpuid(0, a, b, c, d);
     char vendor[13];
-    memcpy(vendor + 0, &b, 4);
-    memcpy(vendor + 4, &d, 4);
-    memcpy(vendor + 8, &c, 4);
+    std::memcpy(vendor + 0, &b, 4);
+    std::memcpy(vendor + 4, &d, 4);
+    std::memcpy(vendor + 8, &c, 4);
     vendor[12] = '\0';
 
     if (strcmp(vendor, "AuthenticAMD") != 0) {

--- a/period_search_optimization_simd/period_search/globals.h
+++ b/period_search_optimization_simd/period_search/globals.h
@@ -52,4 +52,5 @@ extern double Ochisq, Chisq, Alamda, Alamda_incr, Alamda_start, Phi_0, Scale,
 		bool hasSSE3 = false;
 		bool hasSSE2 = false;
 		bool hasASIMD = false;
+		bool isBulldozer = false;
 	} CPUopt;


### PR DESCRIPTION
Bulldozer CPUs feature a dual 128-bit AVX/FMA implementation, but it's pretty bad. Utilizing the SSE3 version on these CPUs can enhance performance by ~30%.

it applies to these architectures (and Opteron variants)
[Bulldozer (microarchitecture)](https://en.wikipedia.org/wiki/Bulldozer_(microarchitecture))
[Piledriver (microarchitecture)](https://en.wikipedia.org/wiki/Piledriver_(microarchitecture))
[Steamroller (microarchitecture)](https://en.wikipedia.org/wiki/Steamroller_(microarchitecture))
[Excavator (microarchitecture)](https://en.wikipedia.org/wiki/Excavator_(microarchitecture))

* tested on Piledriver