### PR TITLE
remove CL_DEVICE_MAX_SAMPLERS

### DIFF
--- a/period_search_opencl_amd/period_search/Start_OpenCl.cpp
+++ b/period_search_opencl_amd/period_search/Start_OpenCl.cpp
@@ -160,7 +160,6 @@ cl_int SaveKernelsToBinary(cl_program binProgram, const char* kernelFileName)
 
     fwrite(binary, binary_size, 1, fp);
     fclose(fp);
-    free(binary);
 
     //std::ofstream file(kernelFileName, std::ios::binary);
     ////size_t binary_size = file.tellg();
@@ -397,7 +396,6 @@ cl_int ClPrepare(cl_int deviceId, cl_double* beta_pole, cl_double* lambda_pole, 
     cerr << "OpenCL device name: " << deviceName << " " << globalMemory << sufix << endl;
     cerr << "Device driver version: " << driverVersion << endl;
     cerr << "Multiprocessors: " << msCount << endl;
-    cerr << "Max Samplers: " << block << endl;
     cerr << "Max work item dimensions: " << devMaxWorkItemDims << endl;
 #ifdef _DEBUG
     cerr << "Debug info:" << endl;
@@ -431,7 +429,7 @@ cl_int ClPrepare(cl_int deviceId, cl_double* beta_pole, cl_double* lambda_pole, 
         return (1);
     }
 
-    auto SMXBlock = block; // 32;
+    auto SMXBlock = 32;
     //CUDA_grid_dim = msCount * SMXBlock; //  24 * 32
     //CUDA_grid_dim = 8 * 32 = 256; 6 * 32 = 192
     CUDA_grid_dim = 2 * msCount * SMXBlock; // 256 (RX 550), 384 (1050Ti), 1536 (Nvidia GTX1660Ti), 768 (Intel Graphics HD)

--- a/period_search_opencl_amd/period_search/Start_OpenCl_Intel.cpp
+++ b/period_search_opencl_amd/period_search/Start_OpenCl_Intel.cpp
@@ -195,7 +195,6 @@ cl_int SaveKernelsToBinary(cl_program binProgram, const char* kernelFileName)
 
      fwrite(binary, binary_size, 1, fp);
      fclose(fp);
-     free(binary);
 
     //std::ofstream file(kernelFileName, std::ios::binary);
     ////size_t binary_size = file.tellg();
@@ -427,7 +426,6 @@ cl_int ClPrepare(cl_int deviceId, cl_double* beta_pole, cl_double* lambda_pole, 
     cerr << "OpenCL device name: " << deviceName << " " << globalMemory << sufix << endl;
 
     cerr << "Multiprocessors: " << msCount << endl;
-    cerr << "Max Samplers: " << block << endl;
     cerr << "Max work item dimensions: " << devMaxWorkItemDims << endl;
 #ifdef _DEBUG
     cerr << "Debug info:" << endl;
@@ -469,7 +467,7 @@ cl_int ClPrepare(cl_int deviceId, cl_double* beta_pole, cl_double* lambda_pole, 
         exit(-1);
     }
 
-    auto SMXBlock = block; // 32;
+    auto SMXBlock = 32;
     //CUDA_grid_dim = msCount * SMXBlock; //  24 * 32
     //CUDA_grid_dim = 8 * 32 = 256; 6 * 32 = 192
     CUDA_grid_dim = msCount * SMXBlock; // 256 (RX 550), 384 (1050Ti), 1536 (Nvidia GTX1660Ti), 768 (Intel Graphics HD)


### PR DESCRIPTION
```
CL_DEVICE_MAX_SAMPLERS is an OpenCL device query parameter that defines the maximum number of samplers that a device can support in an OpenCL kernel. A sampler is an object that defines how texture data is accessed and processed, particularly when working with images (textures) in OpenCL. The sampler allows you to specify how an image should be fetched, including details like filtering mode, addressing mode, and normalization.

Explanation:
    Sampler in OpenCL: A sampler is used to describe how an image should be read, and it works together with image objects. In GPU-based computation, images (textures) can be sampled with different methods, such as linear or nearest neighbor interpolation, and can have different boundary conditions (e.g., wrapping or clamping).
    CL_DEVICE_MAX_SAMPLERS: This value specifies the number of samplers a device can handle simultaneously in a kernel execution. It tells you the maximum number of image samplers that you can use when writing OpenCL kernels for a specific device.
```

The value isn't suitable for the Grid dimension calculation.

for instance, 7900 XTX reports 16 (lower intensity) and very slow Ryzen iGPU reports 32 (higher intensity). Some drivers even report too high values that lead to crashes, see https://asteroidsathome.net/boinc/forum_thread.php?id=967&postid=8687#8687

the CUDA version hardcodes the value based on the architecture (8-32)
https://github.com/AsteroidsAtHome/PeriodSearch/blob/ecd7f1dccb97acc3290a58f3920c9b1aa3a23656/period_search_cuda/period_search/ComputeCapability.cu#L89