### PR TITLE
Update x64.yml

### DIFF
--- a/.github/workflows/x64.yml
+++ b/.github/workflows/x64.yml
@@ -63,7 +63,7 @@ jobs:
           wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.1-1_all.deb
           sudo dpkg -i cuda-keyring_1.1-1_all.deb
           sudo apt-get update
-          sudo apt-get -y install cuda-toolkit
+          sudo apt-get -y install cuda-toolkit-11-8
 
           sed -i 's/CUDA_PATH\s*=.*$/CUDA_PATH = \/usr\/local\/cuda/' ${{ matrix.working-directory }}/${{ matrix.makefile }}
 


### PR DESCRIPTION
Replaces 
`sudo apt-get -y install cuda-toolkit`
with 
`sudo apt-get -y install cuda-toolkit-11-8`