### PR TITLE
[debug/windows] fix localtime

### DIFF
--- a/period_search_optimization_simd/period_search/period_search_BOINC.cpp
+++ b/period_search_optimization_simd/period_search/period_search_BOINC.cpp
@@ -1094,7 +1094,7 @@ int main(int argc, char** argv)
         auto fraction = fraction_done * 100;
         auto time = std::time(nullptr);   // get time now
         std::tm now{};
-#ifdef __GNUC__
+#ifdef defined __GNUC__ && !defined _WIN32
         localtime_r(&time, &now);
 #else
         _localtime64_s(&now, &time);

--- a/period_search_optimization_simd/period_search/period_search_BOINC.cpp
+++ b/period_search_optimization_simd/period_search/period_search_BOINC.cpp
@@ -1094,7 +1094,7 @@ int main(int argc, char** argv)
         auto fraction = fraction_done * 100;
         auto time = std::time(nullptr);   // get time now
         std::tm now{};
-#ifdef defined __GNUC__ && !defined _WIN32
+#if defined __GNUC__ && !defined _WIN32
         localtime_r(&time, &now);
 #else
         _localtime64_s(&now, &time);


### PR DESCRIPTION
gcc+win in debug mode

```
period_search_BOINC.cpp: In function 'int main(int, char**)':
period_search_BOINC.cpp:1098:9: error: 'localtime_r' was not declared in this scope; did you mean 'localtime_s'?
 1098 |         localtime_r(&time, &now);
      |         ^~~~~~~~~~~
      |         localtime_s
```