### PR TITLE
[ci] gha upgrade to ubuntu 2204

### DIFF
--- a/.github/workflows/x64.yml
+++ b/.github/workflows/x64.yml
@@ -30,9 +30,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { variant: 'cuda', os: 'ubuntu-20.04', working-directory: './period_search_cuda/period_search', makefile: 'Makefile' }
-          - { variant: 'opencl', os: 'ubuntu-20.04', working-directory: './period_search_opencl_amd/period_search', makefile: 'Makefile' }
-          - { variant: 'cpu', os: 'ubuntu-20.04', working-directory: './period_search_optimization_simd/period_search', makefile: 'Makefile' }
+          - { variant: 'cuda', os: 'ubuntu-22.04', working-directory: './period_search_cuda/period_search', makefile: 'Makefile' }
+          - { variant: 'opencl', os: 'ubuntu-22.04', working-directory: './period_search_opencl_amd/period_search', makefile: 'Makefile' }
+          - { variant: 'cpu', os: 'ubuntu-22.04', working-directory: './period_search_optimization_simd/period_search', makefile: 'Makefile' }
 
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
       - name: Install cuda
         if: success() && matrix.variant == 'cuda'
         run: |
-          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.1-1_all.deb
+          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
           sudo dpkg -i cuda-keyring_1.1-1_all.deb
           sudo apt-get update
           sudo apt-get -y install cuda-toolkit-11-8


### PR DESCRIPTION
Ubuntu 20.04 Actions runner is no longer supported

https://github.com/actions/runner-images/issues/11101