### PR TITLE
CUDA: memory-locality kernel rewrite — 6.1x vs dev, reference-level accuracy

### DIFF
--- a/period_search_cuda/period_search/Start.cu
+++ b/period_search_cuda/period_search/Start.cu
@@ -11,7 +11,10 @@
 
 __global__ void CudaCalculatePrepare(int n_start, int n_max, double freq_start, double freq_step)
 {
-	const auto n = n_start + blockIdx.x;
+	/* one block per (frequency, pole) pair: N_POLES consecutive blocks share
+	   the same trial frequency and each of them will run one of the initial
+	   poles, all concurrently (the poles used to be a serial host-side loop) */
+	const auto n = n_start + blockIdx.x / N_POLES;
 	const auto CUDA_LCC = &CUDA_CC[blockIdx.x];
 	const auto CUDA_LFR = &CUDA_FR[blockIdx.x];
 
@@ -37,10 +40,13 @@ __global__ void CudaCalculatePrepare(int n_start, int n_max, double freq_start, 
 	(*CUDA_LFR).dev_best = 1e40;
 }
 
-__global__ void CudaCalculatePreparePole(int m)
+__global__ void CudaCalculatePreparePole(void)
 {
 	const auto CUDA_LCC = &CUDA_CC[blockIdx.x];
 	const auto CUDA_LFR = &CUDA_FR[blockIdx.x];
+
+	/* which of the initial poles this block runs (see CudaCalculatePrepare) */
+	const auto m = static_cast<int>(blockIdx.x) % N_POLES + 1;
 
 	if ((*CUDA_LCC).isInvalid)
 	{

--- a/period_search_cuda/period_search/Start.cu
+++ b/period_search_cuda/period_search/Start.cu
@@ -228,6 +228,7 @@ __global__ void CudaCalculateIter1Mrqcof1End(void)
 	if (!(*CUDA_LCC).isAlamda) return;
 
 	(*CUDA_LCC).Ochisq = mrqcof_end(CUDA_LCC, (*CUDA_LCC).alpha);
+
 }
 
 __global__ void CudaCalculateIter1Mrqcof2Start(void)

--- a/period_search_cuda/period_search/Start.cuh
+++ b/period_search_cuda/period_search/Start.cuh
@@ -2,7 +2,7 @@
 
 __global__ void CudaCalculatePrepare(int n_start, int n_max, double freq_start, double freq_step);
 
-__global__ void CudaCalculatePreparePole(int m);
+__global__ void CudaCalculatePreparePole(void);
 
 __global__ void CudaCalculateIter1Begin(void);
 

--- a/period_search_cuda/period_search/bright.cu
+++ b/period_search_cuda/period_search/bright.cu
@@ -1,352 +1,433 @@
-/* computes integrated brightness of all visible and iluminated areas
+/* computes integrated brightness of all visible and illuminated areas
    and its derivatives
 
    8.11.2006
+
+   2026: rewritten as a warp-cooperative kernel for memory locality.
+
+   Key ideas (measured on a Tesla V100, see the pull request for numbers):
+
+   * The per-block matrix Dg is rank-1 redundant: curv() computes
+	 Dg[i + k*Numfac1] = g_i * CUDA_Dsph[i][k], and bright consumed it as
+	 dbr_i * Dg[..] with dbr_i = Darea_i * s. Since Area_i = Darea_i * g_i,
+	 the g factor folds into the weight:
+
+	 dbr_i * Dg[i][k] == (Area_i * s) * CUDA_Dsph[i][k]
+
+	 so every block gathers from the ONE global, facet-major, read-only
+	 CUDA_Dsph matrix (cache-resident for all blocks) instead of a private
+	 ~116 KB Dg that thrashes L1/L2 with 8-byte scattered reads.
+
+   * One warp processes one (frequency, pole) block, two data points at a
+	 time: the visibility pass runs lanes-across-facets (coalesced), the
+	 derivative pass runs lanes-across-coefficients reading CUDA_Dsph rows
+	 coalesced, and each row load feeds both points' accumulators.
+
+   * dytemp is stored transposed - dytempT[(jp-1)*DYT_STRIDE + l] - so the
+	 derivative writes here and the tile reads in MrqcofCurve2 are coalesced.
+	 This requires ma <= DYT_STRIDE-1 = 63 (any spherical-harmonics degree
+	 up to 6, i.e. every production workunit); the host enforces it.
+
+   * The per-point geometry (the former matrix_neo pass) is computed
+	 in-kernel, one lane per point, into shared memory: the de, de0, e_1..e0_3 and
+	 jp_Scale/jp_dphp per-point global buffers are gone entirely.
 */
 
 #include <cmath>
 #include "globals_CUDA.h"
+#include "declarations_CUDA.h"
 #include <device_launch_parameters.h>
 
-__device__ void matrix_neo(freq_context* CUDA_LCC, double cg[], int lnp1, int Lpoints)
+/* per-point geometry, replaces matrix_neo: everything bright needs about a
+   single data point, written to po[GEOM_PT_SIZE] (shared memory).
+   layout: 0..15 the 16 nonzero de/de0 sums' factors
+		   (gde{e,e0}{col1,col2,col3} in the naming below),
+		   16..21 e_1..e_3, e0_1..e0_3, 22 Scale, 23 dphp_1, 24 dphp_2,
+		   25 dphp_3 (= alpha)
+   The rotation math is the same as matrix_neo's Blmat/Dblm matrix products,
+   just with the zero entries folded away; inv[] carries the four nonzero
+   primitives taken from Blmat after blmatrix(). */
+
+
+__device__ void __forceinline__ bright_point_geometry(int lnp,
+	double const* __restrict__ inv,
+	double* __restrict__ po)
 {
-    double f, cf, sf, pom, pom0, alpha;
-    double ee_1, ee_2, ee_3, ee0_1, ee0_2, ee0_3, t, tmat;
-    int lnp, jp;
+	double ee_1 = CUDA_ee[lnp * 3 + 0];
+	double ee0_1 = CUDA_ee0[lnp * 3 + 0];
+	double ee_2 = CUDA_ee[lnp * 3 + 1];
+	double ee0_2 = CUDA_ee0[lnp * 3 + 1];
+	double ee_3 = CUDA_ee[lnp * 3 + 2];
+	double ee0_3 = CUDA_ee0[lnp * 3 + 2];
+	double t = CUDA_tim[lnp];
 
-    int brtmph, brtmpl, index;
-    brtmph = Lpoints / CUDA_BLOCK_DIM;
-    if (Lpoints % CUDA_BLOCK_DIM) brtmph++;
-    brtmpl = threadIdx.x * brtmph;
-    brtmph = brtmpl + brtmph;
-    if (brtmph > Lpoints) brtmph = Lpoints;
-    brtmpl++;
+	/* ee and ee0 are unit vectors: their dot is mathematically in [-1,1],
+	   but opposition geometry brings it within ~1e-7 of 1.0 and an
+	   out-of-range rounding would poison every frequency with NaN */
+	double alpha = acos(fmin(1.0, fmax(-1.0, ee_1 * ee0_1 + ee_2 * ee0_2 + ee_3 * ee0_3)));
 
+	/* Exp-lin model (const.term=1.) */
+	double f = exp(-alpha / inv[2]);
+	po[22] = 1 + inv[1] * f + inv[3] * alpha;   /* Scale */
+	po[23] = f;                                 /* dphp_1 */
+	po[24] = inv[1] * f * alpha / (inv[2] * inv[2]); /* dphp_2 */
+	po[25] = alpha;                             /* dphp_3 */
 
-    lnp = lnp1 + brtmpl - 1;
-    for (jp = brtmpl; jp <= brtmph; jp++)
-    {
-        lnp++;
-        ee_1 = CUDA_ee[lnp * 3 + 0];// position vectors
-        ee0_1 = CUDA_ee0[lnp * 3 + 0];
-        ee_2 = CUDA_ee[lnp * 3 + 1];
-        ee0_2 = CUDA_ee0[lnp * 3 + 1];
-        ee_3 = CUDA_ee[lnp * 3 + 2];
-        ee0_3 = CUDA_ee0[lnp * 3 + 2];
-        t = CUDA_tim[lnp];
+	f = inv[0] * t + CUDA_Phi_0;
+	f = fmod(f, 2 * PI); /* may give little different results than Mikko's */
+	double sf, cf;
+	sincos(f, &sf, &cf);
 
-        alpha = acos(ee_1 * ee0_1 + ee_2 * ee0_2 + ee_3 * ee0_3);
+	/* the four nonzero Blmat primitives (set by blmatrix):
+	   inv[7] = Blmat[1][3] = -sin(beta)   inv[8]  = Blmat[3][3] = cos(beta)
+	   inv[9] = Blmat[2][1] = -sin(lambda) inv[10] = Blmat[2][2] = cos(lambda) */
+	double Blmat02 = inv[7], Blmat22 = inv[8], Blmat10 = inv[9], Blmat11 = inv[10];
+	double Blmat00 = Blmat11 * Blmat22;
+	double Blmat01 = Blmat22 * -Blmat10;
+	double msf = -sf;
+	double cbl00 = cf * Blmat00;
+	double sbl10 = sf * Blmat10;
+	double cbl10 = cf * Blmat10;
+	double sbl11 = sf * Blmat11;
+	double cbl11 = cf * Blmat11;
+	double cbl01 = cf * Blmat01;
+	double sbl00 = msf * Blmat00;
+	double sbl01 = msf * Blmat01;
 
-        /* Exp-lin model (const.term=1.) */
-        f = exp(-alpha / cg[CUDA_ncoef0 + 2]);//f is temp here
-        (*CUDA_LCC).jp_Scale[jp] = 1 + cg[CUDA_ncoef0 + 1] * f + cg[CUDA_ncoef0 + 3] * alpha;
-        (*CUDA_LCC).jp_dphp_1[jp] = f;
-        (*CUDA_LCC).jp_dphp_2[jp] = cg[CUDA_ncoef0 + 1] * f * alpha / (cg[CUDA_ncoef0 + 2] * cg[CUDA_ncoef0 + 2]);
-        (*CUDA_LCC).jp_dphp_3[jp] = alpha;
+	double gde020 = Blmat00 * ee_1 + Blmat01 * ee_2 + Blmat02 * ee_3;
+	double gde120 = Blmat00 * ee0_1 + Blmat01 * ee0_2 + Blmat02 * ee0_3;
 
-        //  matrix start
-        f = cg[CUDA_ncoef0] * t + CUDA_Phi_0;
-        f = fmod(f, 2 * PI); /* may give little different results than Mikko's */
-        sincos(f, &sf, &cf);
+	double tmat41 = -cbl01 - sbl11;
+	double tmat51 = -sbl01 - cbl11;
+	double tmat42 = cbl00 + sbl10;
+	double tmat52 = sbl00 + cbl10;
 
-        /* rotation matrix, Z axis, angle f */
-        tmat = cf * (*CUDA_LCC).Blmat[1][1] + sf * (*CUDA_LCC).Blmat[2][1] + 0 * (*CUDA_LCC).Blmat[3][1];
-        pom = tmat * ee_1;
-        pom0 = tmat * ee0_1;
-        tmat = cf * (*CUDA_LCC).Blmat[1][2] + sf * (*CUDA_LCC).Blmat[2][2] + 0 * (*CUDA_LCC).Blmat[3][2];
-        pom += tmat * ee_2;
-        pom0 += tmat * ee0_2;
-        tmat = cf * (*CUDA_LCC).Blmat[1][3] + sf * (*CUDA_LCC).Blmat[2][3] + 0 * (*CUDA_LCC).Blmat[3][3];
-        (*CUDA_LCC).e_1[jp] = pom + tmat * ee_3;
-        (*CUDA_LCC).e0_1[jp] = pom0 + tmat * ee0_3;
+	double gde001 = tmat41 * ee_1 + tmat42 * ee_2;
+	double gde101 = tmat41 * ee0_1 + tmat42 * ee0_2;
+	double gde011 = tmat51 * ee_1 + tmat52 * ee_2;
+	double gde111 = tmat51 * ee0_1 + tmat52 * ee0_2;
 
-        tmat = (-sf) * (*CUDA_LCC).Blmat[1][1] + cf * (*CUDA_LCC).Blmat[2][1] + 0 * (*CUDA_LCC).Blmat[3][1];
-        pom = tmat * ee_1;
-        pom0 = tmat * ee0_1;
-        tmat = (-sf) * (*CUDA_LCC).Blmat[1][2] + cf * (*CUDA_LCC).Blmat[2][2] + 0 * (*CUDA_LCC).Blmat[3][2];
-        pom += tmat * ee_2;
-        pom0 += tmat * ee0_2;
-        tmat = (-sf) * (*CUDA_LCC).Blmat[1][3] + cf * (*CUDA_LCC).Blmat[2][3] + 0 * (*CUDA_LCC).Blmat[3][3];
-        (*CUDA_LCC).e_2[jp] = pom + tmat * ee_3;
-        (*CUDA_LCC).e0_2[jp] = pom0 + tmat * ee0_3;
+	double tmat01 = cbl00 + sbl10;
+	double tmat11 = sbl00 + cbl10;
+	double tmat02 = cbl01 + sbl11;
+	double tmat12 = sbl01 + cbl11;
+	double tmat03 = cf * Blmat02;
+	double tmat13 = msf * Blmat02;
 
-        tmat = 0 * (*CUDA_LCC).Blmat[1][1] + 0 * (*CUDA_LCC).Blmat[2][1] + 1 * (*CUDA_LCC).Blmat[3][1];
-        pom = tmat * ee_1;
-        pom0 = tmat * ee0_1;
-        tmat = 0 * (*CUDA_LCC).Blmat[1][2] + 0 * (*CUDA_LCC).Blmat[2][2] + 1 * (*CUDA_LCC).Blmat[3][2];
-        pom += tmat * ee_2;
-        pom0 += tmat * ee0_2;
-        tmat = 0 * (*CUDA_LCC).Blmat[1][3] + 0 * (*CUDA_LCC).Blmat[2][3] + 1 * (*CUDA_LCC).Blmat[3][3];
-        (*CUDA_LCC).e_3[jp] = pom + tmat * ee_3;
-        (*CUDA_LCC).e0_3[jp] = pom0 + tmat * ee0_3;
+	double ge00 = tmat01 * ee_1 + tmat02 * ee_2 + tmat03 * ee_3;
+	double ge10 = tmat01 * ee0_1 + tmat02 * ee0_2 + tmat03 * ee0_3;
+	double ge01 = tmat11 * ee_1 + tmat12 * ee_2 + tmat13 * ee_3;
+	double ge11 = tmat11 * ee0_1 + tmat12 * ee0_2 + tmat13 * ee0_3;
 
-        tmat = cf * (*CUDA_LCC).Dblm[1][1][1] + sf * (*CUDA_LCC).Dblm[1][2][1] + 0 * (*CUDA_LCC).Dblm[1][3][1];
-        pom = tmat * ee_1;
-        pom0 = tmat * ee0_1;
-        tmat = cf * (*CUDA_LCC).Dblm[1][1][2] + sf * (*CUDA_LCC).Dblm[1][2][2] + 0 * (*CUDA_LCC).Dblm[1][3][2];
-        pom += tmat * ee_2;
-        pom0 += tmat * ee0_2;
-        tmat = cf * (*CUDA_LCC).Dblm[1][1][3] + sf * (*CUDA_LCC).Dblm[1][2][3] + 0 * (*CUDA_LCC).Dblm[1][3][3];
-        index = jp * 16 + 1 * 4 + 1;
-        (*CUDA_LCC).de[index] = pom + tmat * ee_3;
-        (*CUDA_LCC).de0[index] = pom0 + tmat * ee0_3;
+	double Blmat20 = Blmat11 * -Blmat02;
+	double Blmat21 = Blmat02 * Blmat10;
+	double gde002 = t * ge01;
+	double gde102 = t * ge11;
+	double gde012 = -t * ge00;
+	double gde112 = -t * ge10;
 
-        tmat = cf * (*CUDA_LCC).Dblm[2][1][1] + sf * (*CUDA_LCC).Dblm[2][2][1] + 0 * (*CUDA_LCC).Dblm[2][3][1];
-        pom = tmat * ee_1;
-        pom0 = tmat * ee0_1;
-        tmat = cf * (*CUDA_LCC).Dblm[2][1][2] + sf * (*CUDA_LCC).Dblm[2][2][2] + 0 * (*CUDA_LCC).Dblm[2][3][2];
-        pom += tmat * ee_2;
-        pom0 += tmat * ee0_2;
-        tmat = cf * (*CUDA_LCC).Dblm[2][1][3] + sf * (*CUDA_LCC).Dblm[2][2][3] + 0 * (*CUDA_LCC).Dblm[2][3][3];
-        index++; // index = jp * 16 + 1 * 4 + 2;
-        (*CUDA_LCC).de[index] = pom + tmat * ee_3;
-        (*CUDA_LCC).de0[index] = pom0 + tmat * ee0_3;
+	double ge02 = Blmat20 * ee_1 + Blmat21 * ee_2 + Blmat22 * ee_3;
+	double ge12 = Blmat20 * ee0_1 + Blmat21 * ee0_2 + Blmat22 * ee0_3;
+	double gde021 = -Blmat21 * ee_1 + Blmat20 * ee_2;
+	double gde121 = -Blmat21 * ee0_1 + Blmat20 * ee0_2;
 
-        tmat = (-t * sf) * (*CUDA_LCC).Blmat[1][1] + (t * cf) * (*CUDA_LCC).Blmat[2][1] + 0 * (*CUDA_LCC).Blmat[3][1];
-        pom = tmat * ee_1;
-        pom0 = tmat * ee0_1;
-        tmat = (-t * sf) * (*CUDA_LCC).Blmat[1][2] + (t * cf) * (*CUDA_LCC).Blmat[2][2] + 0 * (*CUDA_LCC).Blmat[3][2];
-        pom += tmat * ee_2;
-        pom0 += tmat * ee0_2;
-        tmat = (-t * sf) * (*CUDA_LCC).Blmat[1][3] + (t * cf) * (*CUDA_LCC).Blmat[2][3] + 0 * (*CUDA_LCC).Blmat[3][3];
-        index++; // index = jp * 16 + 1 * 4 + 3;
-        (*CUDA_LCC).de[index] = pom + tmat * ee_3;
-        (*CUDA_LCC).de0[index] = pom0 + tmat * ee0_3;
+	double tmat31 = sf * Blmat20;
+	double tmat32 = sf * Blmat21;
+	double tmat33 = sf * Blmat22;
+	double tmat21 = cf * -Blmat20;
+	double tmat22 = cf * -Blmat21;
+	double tmat23 = cf * -Blmat22;
 
-        tmat = -sf * (*CUDA_LCC).Dblm[1][1][1] + cf * (*CUDA_LCC).Dblm[1][2][1] + 0 * (*CUDA_LCC).Dblm[1][3][1];
-        pom = tmat * ee_1;
-        pom0 = tmat * ee0_1;
-        tmat = -sf * (*CUDA_LCC).Dblm[1][1][2] + cf * (*CUDA_LCC).Dblm[1][2][2] + 0 * (*CUDA_LCC).Dblm[1][3][2];
-        pom += tmat * ee_2;
-        pom0 += tmat * ee0_2;
-        tmat = -sf * (*CUDA_LCC).Dblm[1][1][3] + cf * (*CUDA_LCC).Dblm[1][2][3] + 0 * (*CUDA_LCC).Dblm[1][3][3];
-        index = jp * 16 + 2 * 4 + 1;
-        (*CUDA_LCC).de[index] = pom + tmat * ee_3;
-        (*CUDA_LCC).de0[index] = pom0 + tmat * ee0_3;
+	double gde000 = tmat21 * ee_1 + tmat22 * ee_2 + tmat23 * ee_3;
+	double gde100 = tmat21 * ee0_1 + tmat22 * ee0_2 + tmat23 * ee0_3;
+	double gde010 = tmat31 * ee_1 + tmat32 * ee_2 + tmat33 * ee_3;
+	double gde110 = tmat31 * ee0_1 + tmat32 * ee0_2 + tmat33 * ee0_3;
 
-        tmat = -sf * (*CUDA_LCC).Dblm[2][1][1] + cf * (*CUDA_LCC).Dblm[2][2][1] + 0 * (*CUDA_LCC).Dblm[2][3][1];
-        pom = tmat * ee_1;
-        pom0 = tmat * ee0_1;
-        tmat = -sf * (*CUDA_LCC).Dblm[2][1][2] + cf * (*CUDA_LCC).Dblm[2][2][2] + 0 * (*CUDA_LCC).Dblm[2][3][2];
-        pom += tmat * ee_2;
-        pom0 += tmat * ee0_2;
-        tmat = -sf * (*CUDA_LCC).Dblm[2][1][3] + cf * (*CUDA_LCC).Dblm[2][2][3] + 0 * (*CUDA_LCC).Dblm[2][3][3];
-        index++; // index = jp * 16 + 2 * 4 + 2;
-        (*CUDA_LCC).de[index] = pom + tmat * ee_3;
-        (*CUDA_LCC).de0[index] = pom0 + tmat * ee0_3;
-
-        tmat = (-t * cf) * (*CUDA_LCC).Blmat[1][1] + (-t * sf) * (*CUDA_LCC).Blmat[2][1] + 0 * (*CUDA_LCC).Blmat[3][1];
-        pom = tmat * ee_1;
-        pom0 = tmat * ee0_1;
-        tmat = (-t * cf) * (*CUDA_LCC).Blmat[1][2] + (-t * sf) * (*CUDA_LCC).Blmat[2][2] + 0 * (*CUDA_LCC).Blmat[3][2];
-        pom += tmat * ee_2;
-        pom0 += tmat * ee0_2;
-        tmat = (-t * cf) * (*CUDA_LCC).Blmat[1][3] + (-t * sf) * (*CUDA_LCC).Blmat[2][3] + 0 * (*CUDA_LCC).Blmat[3][3];
-        index++; // index = jp * 16 + 2 * 4 + 3;
-        (*CUDA_LCC).de[index] = pom + tmat * ee_3;
-        (*CUDA_LCC).de0[index] = pom0 + tmat * ee0_3;
-
-        tmat = 0 * (*CUDA_LCC).Dblm[1][1][1] + 0 * (*CUDA_LCC).Dblm[1][2][1] + 1 * (*CUDA_LCC).Dblm[1][3][1];
-        pom = tmat * ee_1;
-        pom0 = tmat * ee0_1;
-        tmat = 0 * (*CUDA_LCC).Dblm[1][1][2] + 0 * (*CUDA_LCC).Dblm[1][2][2] + 1 * (*CUDA_LCC).Dblm[1][3][2];
-        pom += tmat * ee_2;
-        pom0 += tmat * ee0_2;
-        tmat = 0 * (*CUDA_LCC).Dblm[1][1][3] + 0 * (*CUDA_LCC).Dblm[1][2][3] + 1 * (*CUDA_LCC).Dblm[1][3][3];
-        index = jp * 16 + 3 * 4 + 1;
-        (*CUDA_LCC).de[index] = pom + tmat * ee_3;
-        (*CUDA_LCC).de0[index] = pom0 + tmat * ee0_3;
-
-        tmat = 0 * (*CUDA_LCC).Dblm[2][1][1] + 0 * (*CUDA_LCC).Dblm[2][2][1] + 1 * (*CUDA_LCC).Dblm[2][3][1];
-        pom = tmat * ee_1;
-        pom0 = tmat * ee0_1;
-        tmat = 0 * (*CUDA_LCC).Dblm[2][1][2] + 0 * (*CUDA_LCC).Dblm[2][2][2] + 1 * (*CUDA_LCC).Dblm[2][3][2];
-        pom += tmat * ee_2;
-        pom0 += tmat * ee0_2;
-        tmat = 0 * (*CUDA_LCC).Dblm[2][1][3] + 0 * (*CUDA_LCC).Dblm[2][2][3] + 1 * (*CUDA_LCC).Dblm[2][3][3];
-        index++; // index = jp * 16 + 3 * 4 + 2;
-        (*CUDA_LCC).de[index] = pom + tmat * ee_3;
-        (*CUDA_LCC).de0[index] = pom0 + tmat * ee0_3;
-
-        tmat = 0 * (*CUDA_LCC).Blmat[1][1] + 0 * (*CUDA_LCC).Blmat[2][1] + 0 * (*CUDA_LCC).Blmat[3][1];
-        pom = tmat * ee_1;
-        pom0 = tmat * ee0_1;
-        tmat = 0 * (*CUDA_LCC).Blmat[1][2] + 0 * (*CUDA_LCC).Blmat[2][2] + 0 * (*CUDA_LCC).Blmat[3][2];
-        pom += tmat * ee_2;
-        pom0 += tmat * ee0_2;
-        tmat = 0 * (*CUDA_LCC).Blmat[1][3] + 0 * (*CUDA_LCC).Blmat[2][3] + 0 * (*CUDA_LCC).Blmat[3][3];
-        index++; // index = jp * 16 + 3 * 4 + 3;
-        (*CUDA_LCC).de[index] = pom + tmat * ee_3;
-        (*CUDA_LCC).de0[index] = pom0 + tmat * ee0_3;
-
-    }
-    __syncthreads();
+	po[0] = gde000;  po[1] = gde010;  po[2] = gde020;
+	po[3] = gde100;  po[4] = gde110;  po[5] = gde120;
+	po[6] = gde001;  po[7] = gde011;  po[8] = gde021;
+	po[9] = gde101;  po[10] = gde111; po[11] = gde121;
+	po[12] = gde002; po[13] = gde012;
+	po[14] = gde102; po[15] = gde112;
+	po[16] = ge00;   po[17] = ge01;   po[18] = ge02;
+	po[19] = ge10;   po[20] = ge11;   po[21] = ge12;
 }
-__device__ double bright(freq_context* CUDA_LCC, double cg[], int jp, int Lpoints1, int Inrel)
+
+/* the whole former matrix_neo + per-point bright loop for one lightcurve,
+   executed by ONE WARP per block. Handles both relative (Inrel=1) and
+   absolute (Inrel=0) lightcurves; updates dave/ave/np exactly as the old
+   mrqcof_curve1 did. */
+__device__ void bright_curve1_warp(freq_context* __restrict__ CUDA_LCC,
+	double const* __restrict__ a,
+	int Inrel, int Lpoints)
 {
-    int ncoef0, ncoef, i, j, incl_count = 0;
-    double cl, cls, dnom, s, Scale;
-    double e_1, e_2, e_3, e0_1, e0_2, e0_3, de[4][4], de0[4][4];
+	const int tid = threadIdx.x;
+	brightshare* __restrict__ shw = &mrq_share_block()->b;
+	double* __restrict__ wcA = shw->wcA;
+	double* __restrict__ wcB = shw->wcB;
+	int* __restrict__ fc = shw->fc;
+	double* __restrict__ inv = shw->inv;
 
-    ncoef0 = CUDA_ncoef0;//ncoef - 2 - CUDA_Nphpar;
-    ncoef = CUDA_ma;
-    cl = exp(cg[ncoef - 1]); /* Lambert */
-    cls = cg[ncoef];       /* Lommel-Seeliger */
+	const int nc = CUDA_ncoef0;
+	const int ma = CUDA_ma;
+	const int nshape = nc - 3;           /* last shape-coefficient row */
+	const int nf = CUDA_Numfac;
+	const int lnp0 = (*CUDA_LCC).np;
+	const int iStart = Inrel + 1;        /* absolute lightcurves keep row 1 */
 
-    /* matrix from neo */
-    /* derivatives */
+	if (tid == 0)
+	{
+		inv[0] = a[nc];          /* omega */
+		inv[1] = a[nc + 1];
+		inv[2] = a[nc + 2];
+		inv[3] = a[nc + 3];
+		inv[4] = 0;              /* unused (kept for layout clarity) */
+		inv[5] = exp(a[ma - 1]); /* Lambert */
+		inv[6] = a[ma];          /* Lommel-Seeliger */
+		inv[7] = (*CUDA_LCC).Blmat[1][3];
+		inv[8] = (*CUDA_LCC).Blmat[3][3];
+		inv[9] = (*CUDA_LCC).Blmat[2][1];
+		inv[10] = (*CUDA_LCC).Blmat[2][2];
+	}
+	__syncwarp();
 
-    e_1 = (*CUDA_LCC).e_1[jp];
-    e_2 = (*CUDA_LCC).e_2[jp];
-    e_3 = (*CUDA_LCC).e_3[jp];
-    e0_1 = (*CUDA_LCC).e0_1[jp];
-    e0_2 = (*CUDA_LCC).e0_2[jp];
-    e0_3 = (*CUDA_LCC).e0_3[jp];
+	/* each lane owns two parameter rows across the whole curve */
+	const int c1 = 1 + tid;   /* rows 1..32 */
+	const int c2 = 33 + tid;  /* rows 33..64 */
+	double dave1 = 0, dave2 = 0;
+	double lave = 0;
 
-    // Loop over the indices to map to flattened array
-    for (int i = 1; i <= 3; ++i) 
-    {
-        for (int j = 1; j <= 3; ++j) 
-        {
-            // Calculate the flattened index for 'de' and 'de0'
-            int index = jp * (4 * 4) + i * 4 + j;
-            de[i][j] = (*CUDA_LCC).de[index];
-            de0[i][j] = (*CUDA_LCC).de0[index];
-        }
-    }
+	double const* __restrict__ areap = &CUDA_Area[blockIdx.x * CUDA_Numfac1];
+	double* __restrict__ dytemp = (*CUDA_LCC).dytemp;
+	double* __restrict__ ytemp = (*CUDA_LCC).ytemp;
 
-    // index = x * 16 + y * 4 + z;
+#pragma unroll 1
+	for (int jp0 = 1; jp0 <= Lpoints; jp0 += GEO_BATCH)
+	{
+		int nb = Lpoints - jp0 + 1;
+		if (nb > GEO_BATCH) nb = GEO_BATCH;
 
-    /* Directions (and ders.) in the rotating system */
+		/* one lane computes one point's geometry (the acos/sincos/exp-heavy
+		   part runs once per point instead of once per lane per point) */
+		if (tid < nb)
+			bright_point_geometry(lnp0 + jp0 + tid, inv, shw->geo[tid]);
+		__syncwarp();
 
-    //
-    /*Integrated brightness (phase coeff. used later) */
-    double lmu, lmu0, dsmu, dsmu0, sum1, sum10, sum2, sum20, sum3, sum30;
-    double br, ar, tmp1, tmp2, tmp3, tmp4, tmp5;
-    //   short int *incl=&(*CUDA_LCC).incl[threadIdx.x*MAX_N_FAC];
-    //   double *dbr=&(*CUDA_LCC).dbr[threadIdx.x*MAX_N_FAC];
-    short int incl[MAX_N_FAC];
-    double dbr[MAX_N_FAC];
-    //int2 bfr;
+		/* two points (A = jp, B = jp+1) share every CUDA_Dsph row load */
+#pragma unroll 1
+		for (int jp = jp0; jp < jp0 + nb; jp += 2)
+		{
+			const int haveB = (jp + 1 < jp0 + nb);
+			double const* __restrict__ ptA = shw->geo[jp - jp0];
+			double const* __restrict__ ptB = shw->geo[jp - jp0 + (haveB ? 1 : 0)];
 
-    br = 0;
-    tmp1 = 0;
-    tmp2 = 0;
-    tmp3 = 0;
-    tmp4 = 0;
-    tmp5 = 0;
-    j = blockIdx.x * (CUDA_Numfac1)+1;
-    for (i = 1; i <= CUDA_Numfac; i++, j++)
-    {
-        lmu = e_1 * CUDA_Nor[i][0] + e_2 * CUDA_Nor[i][1] + e_3 * CUDA_Nor[i][2];
-        lmu0 = e0_1 * CUDA_Nor[i][0] + e0_2 * CUDA_Nor[i][1] + e0_3 * CUDA_Nor[i][2];
-        if ((lmu > TINY) && (lmu0 > TINY))
-        {
-            dnom = lmu + lmu0;
-            s = lmu * lmu0 * (cl + cls / dnom);
-            ar = CUDA_Area[j];
-            br += ar * s;
-            //
-            incl[incl_count] = i;
-            dbr[incl_count] = CUDA_Darea[i] * s;
-            incl_count++;
+			double brA = 0, t1A = 0, t2A = 0, t3A = 0, t4A = 0, t5A = 0;
+			double brB = 0, t1B = 0, t2B = 0, t3B = 0, t4B = 0, t5B = 0;
+			double accA1 = 0, accA2 = 0, accB1 = 0, accB2 = 0;
 
-            auto lmu0_dnom = lmu0 / dnom;
-            dsmu = cls * (lmu0_dnom * lmu0_dnom) + cl * lmu0;
-            auto lmu_dnom = lmu / dnom;
-            dsmu0 = cls * (lmu_dnom * lmu_dnom) + cl * lmu;
+#pragma unroll 1
+			for (int f0 = 1; f0 <= nf; f0 += 32)
+			{
+				const int i = f0 + tid;
+				double dbrA = 0.0, dbrB = 0.0;
+				if (i <= nf)
+				{
+					double n0 = CUDA_Nor[i][0], n1 = CUDA_Nor[i][1], n2 = CUDA_Nor[i][2];
+					double ar = areap[i];
+					double cl = inv[5], cls = inv[6];
 
+					{
+						double lmu = ptA[16] * n0 + ptA[17] * n1 + ptA[18] * n2;
+						double lmu0 = ptA[19] * n0 + ptA[20] * n1 + ptA[21] * n2;
+						if ((lmu > TINY) && (lmu0 > TINY))
+						{
+							double dnom = lmu + lmu0;
+							double s = lmu * lmu0 * (cl + cls / dnom);
+							brA += ar * s;
+							dbrA = ar * s;   /* == (Darea*s) * g : the fold */
+							double lmu0_dnom = lmu0 / dnom;
+							double dsmu = cls * (lmu0_dnom * lmu0_dnom) + cl * lmu0;
+							double lmu_dnom = lmu / dnom;
+							double dsmu0 = cls * (lmu_dnom * lmu_dnom) + cl * lmu;
 
-            sum1 = CUDA_Nor[i][0] * de[1][1] + CUDA_Nor[i][1] * de[2][1] + CUDA_Nor[i][2] * de[3][1];
-            sum10 = CUDA_Nor[i][0] * de0[1][1] + CUDA_Nor[i][1] * de0[2][1] + CUDA_Nor[i][2] * de0[3][1];
-            tmp1 += ar * (dsmu * sum1 + dsmu0 * sum10);
-            sum2 = CUDA_Nor[i][0] * de[1][2] + CUDA_Nor[i][1] * de[2][2] + CUDA_Nor[i][2] * de[3][2];
-            sum20 = CUDA_Nor[i][0] * de0[1][2] + CUDA_Nor[i][1] * de0[2][2] + CUDA_Nor[i][2] * de0[3][2];
-            tmp2 += ar * (dsmu * sum2 + dsmu0 * sum20);
-            sum3 = CUDA_Nor[i][0] * de[1][3] + CUDA_Nor[i][1] * de[2][3] + CUDA_Nor[i][2] * de[3][3];
-            sum30 = CUDA_Nor[i][0] * de0[1][3] + CUDA_Nor[i][1] * de0[2][3] + CUDA_Nor[i][2] * de0[3][3];
-            tmp3 += ar * (dsmu * sum3 + dsmu0 * sum30);
+							double sum1 = n0 * ptA[0] + n1 * ptA[1] + n2 * ptA[2];
+							double sum10 = n0 * ptA[3] + n1 * ptA[4] + n2 * ptA[5];
+							double sum2 = n0 * ptA[6] + n1 * ptA[7] + n2 * ptA[8];
+							double sum20 = n0 * ptA[9] + n1 * ptA[10] + n2 * ptA[11];
+							double sum3 = n0 * ptA[12] + n1 * ptA[13];
+							double sum30 = n0 * ptA[14] + n1 * ptA[15];
 
-            tmp4 += lmu * lmu0 * ar;
-            tmp5 += ar * lmu * lmu0 / (lmu + lmu0);
-        }
-    }
-    Scale = (*CUDA_LCC).jp_Scale[jp];
-    i = jp + (ncoef0 - 3 + 1) * Lpoints1;
+							t1A += ar * (dsmu * sum1 + dsmu0 * sum10);
+							t2A += ar * (dsmu * sum2 + dsmu0 * sum20);
+							t3A += ar * (dsmu * sum3 + dsmu0 * sum30);
+							t4A += lmu * lmu0 * ar;
+							t5A += ar * lmu * lmu0 / (lmu + lmu0);
+						}
+					}
+					if (haveB)
+					{
+						double lmu = ptB[16] * n0 + ptB[17] * n1 + ptB[18] * n2;
+						double lmu0 = ptB[19] * n0 + ptB[20] * n1 + ptB[21] * n2;
+						if ((lmu > TINY) && (lmu0 > TINY))
+						{
+							double dnom = lmu + lmu0;
+							double s = lmu * lmu0 * (cl + cls / dnom);
+							brB += ar * s;
+							dbrB = ar * s;
+							double lmu0_dnom = lmu0 / dnom;
+							double dsmu = cls * (lmu0_dnom * lmu0_dnom) + cl * lmu0;
+							double lmu_dnom = lmu / dnom;
+							double dsmu0 = cls * (lmu_dnom * lmu_dnom) + cl * lmu;
 
-    /* Ders. of brightness w.r.t. rotation parameters */
-    (*CUDA_LCC).dytemp[i] = Scale * tmp1;
-    i += Lpoints1;
-    (*CUDA_LCC).dytemp[i] = Scale * tmp2;
-    i += Lpoints1;
-    (*CUDA_LCC).dytemp[i] = Scale * tmp3;
-    i += Lpoints1;
+							double sum1 = n0 * ptB[0] + n1 * ptB[1] + n2 * ptB[2];
+							double sum10 = n0 * ptB[3] + n1 * ptB[4] + n2 * ptB[5];
+							double sum2 = n0 * ptB[6] + n1 * ptB[7] + n2 * ptB[8];
+							double sum20 = n0 * ptB[9] + n1 * ptB[10] + n2 * ptB[11];
+							double sum3 = n0 * ptB[12] + n1 * ptB[13];
+							double sum30 = n0 * ptB[14] + n1 * ptB[15];
 
-    /* Ders. of br. w.r.t. phase function params. */
-    (*CUDA_LCC).dytemp[i] = br * (*CUDA_LCC).jp_dphp_1[jp];
-    i += Lpoints1;
-    (*CUDA_LCC).dytemp[i] = br * (*CUDA_LCC).jp_dphp_2[jp];
-    i += Lpoints1;
-    (*CUDA_LCC).dytemp[i] = br * (*CUDA_LCC).jp_dphp_3[jp];
+							t1B += ar * (dsmu * sum1 + dsmu0 * sum10);
+							t2B += ar * (dsmu * sum2 + dsmu0 * sum20);
+							t3B += ar * (dsmu * sum3 + dsmu0 * sum30);
+							t4B += lmu * lmu0 * ar;
+							t5B += ar * lmu * lmu0 / (lmu + lmu0);
+						}
+					}
+				}
 
-    /* Ders. of br. w.r.t. cl, cls */
-    (*CUDA_LCC).dytemp[jp + (ncoef - 1) * (Lpoints1)] = Scale * tmp4 * cl;
-    (*CUDA_LCC).dytemp[jp + (ncoef) * (Lpoints1)] = Scale * tmp5;
+				/* compact the visible facets (union of both points) so the
+				   derivative sweep below is branch-free with independent,
+				   pipelineable loads */
+				unsigned vis = __ballot_sync(0xffffffff, (dbrA != 0.0) || (dbrB != 0.0));
+				int cnt = __popc(vis);
+				if ((dbrA != 0.0) || (dbrB != 0.0))
+				{
+					int pos = __popc(vis & ((1u << tid) - 1u));
+					wcA[pos] = dbrA;
+					wcB[pos] = dbrB;
+					fc[pos] = i;
+				}
+				__syncwarp();
 
-    /* Scaled brightness */
-    (*CUDA_LCC).ytemp[jp] = br * Scale;
+#pragma unroll 4
+				for (int j = 0; j < cnt; j++)
+				{
+					double wA = wcA[j];
+					double wB = wcB[j];
+					double const* __restrict__ row = CUDA_Dsph[fc[j]];
+					double v1 = row[c1];
+					accA1 += wA * v1;
+					accB1 += wB * v1;
+					if (c2 <= nshape)
+					{
+						double v2 = row[c2];
+						accA2 += wA * v2;
+						accB2 += wB * v2;
+					}
+				}
+				__syncwarp();
+			} /* facet chunks */
 
-    ncoef0 -= 3;
-    int m, m1, mr, iStart;
-    int d, d1, dr;
+			/* butterfly-reduce both points' sums so every lane has them */
+#pragma unroll
+			for (int off = 16; off > 0; off >>= 1)
+			{
+				brA += __shfl_xor_sync(0xffffffff, brA, off);
+				t1A += __shfl_xor_sync(0xffffffff, t1A, off);
+				t2A += __shfl_xor_sync(0xffffffff, t2A, off);
+				t3A += __shfl_xor_sync(0xffffffff, t3A, off);
+				t4A += __shfl_xor_sync(0xffffffff, t4A, off);
+				t5A += __shfl_xor_sync(0xffffffff, t5A, off);
+				brB += __shfl_xor_sync(0xffffffff, brB, off);
+				t1B += __shfl_xor_sync(0xffffffff, t1B, off);
+				t2B += __shfl_xor_sync(0xffffffff, t2B, off);
+				t3B += __shfl_xor_sync(0xffffffff, t3B, off);
+				t4B += __shfl_xor_sync(0xffffffff, t4B, off);
+				t5B += __shfl_xor_sync(0xffffffff, t5B, off);
+			}
 
-    iStart = Inrel + 1;
-    m = blockIdx.x * CUDA_Dg_block + iStart * (CUDA_Numfac1);
-    d = jp + (Lpoints1 << Inrel);
+			/* one transposed dytemp row per point, lanes = parameters */
+			{
+				double Scale = ptA[22], dphp1 = ptA[23], dphp2 = ptA[24], dphp3 = ptA[25];
+				double cl = inv[5];
+				double ymod = brA * Scale;
+				double* __restrict__ row = dytemp + (size_t)(jp - 1) * DYT_STRIDE;
 
-    m1 = m + (CUDA_Numfac1);
-    mr = 2 * CUDA_Numfac1;
-    d1 = d + (Lpoints1);
-    dr = 2 * Lpoints1;
-    /* Derivatives of brightness w.r.t. g-coeffs */
-    if (incl_count)
-    {
-        for (i = iStart; i <= ncoef0; i += 2, m += mr, m1 += mr, d += dr, d1 += dr)
-        {
-            double tmp = 0, tmp1 = 0;
+				double v1, v2;
+				if (c1 <= nshape)           v1 = Scale * accA1;
+				else if (c1 == nshape + 1)  v1 = Scale * t1A;
+				else if (c1 == nshape + 2)  v1 = Scale * t2A;
+				else if (c1 == nshape + 3)  v1 = Scale * t3A;
+				else if (c1 == nc + 1)      v1 = brA * dphp1;
+				else if (c1 == nc + 2)      v1 = brA * dphp2;
+				else if (c1 == nc + 3)      v1 = brA * dphp3;
+				else if (c1 == ma - 1)      v1 = Scale * t4A * cl;
+				else                        v1 = Scale * t5A; /* c1 == ma */
+				if (c2 <= nshape)           v2 = Scale * accA2;
+				else if (c2 == nshape + 1)  v2 = Scale * t1A;
+				else if (c2 == nshape + 2)  v2 = Scale * t2A;
+				else if (c2 == nshape + 3)  v2 = Scale * t3A;
+				else if (c2 == nc + 1)      v2 = brA * dphp1;
+				else if (c2 == nc + 2)      v2 = brA * dphp2;
+				else if (c2 == nc + 3)      v2 = brA * dphp3;
+				else if (c2 == ma - 1)      v2 = Scale * t4A * cl;
+				else                        v2 = Scale * t5A; /* c2 == ma */
 
-            double l_dbr = dbr[0];
-            int l_incl = incl[0];
+				if (c1 >= iStart && c1 <= ma) { row[c1] = v1; if (c1 >= 2) dave1 += v1; }
+				if (c2 <= ma) { row[c2] = v2; dave2 += v2; }
+				if (tid == 0) ytemp[jp] = ymod;
+				lave += ymod;
+			}
+			if (haveB)
+			{
+				double Scale = ptB[22], dphp1 = ptB[23], dphp2 = ptB[24], dphp3 = ptB[25];
+				double cl = inv[5];
+				double ymod = brB * Scale;
+				double* __restrict__ row = dytemp + (size_t)jp * DYT_STRIDE;
 
-            tmp = l_dbr * CUDA_Dg[m + l_incl];
-            if ((i + 1) <= ncoef0)
-            {
-                tmp1 = l_dbr * CUDA_Dg[m1 + l_incl];
-            }
+				double v1, v2;
+				if (c1 <= nshape)           v1 = Scale * accB1;
+				else if (c1 == nshape + 1)  v1 = Scale * t1B;
+				else if (c1 == nshape + 2)  v1 = Scale * t2B;
+				else if (c1 == nshape + 3)  v1 = Scale * t3B;
+				else if (c1 == nc + 1)      v1 = brB * dphp1;
+				else if (c1 == nc + 2)      v1 = brB * dphp2;
+				else if (c1 == nc + 3)      v1 = brB * dphp3;
+				else if (c1 == ma - 1)      v1 = Scale * t4B * cl;
+				else                        v1 = Scale * t5B;
+				if (c2 <= nshape)           v2 = Scale * accB2;
+				else if (c2 == nshape + 1)  v2 = Scale * t1B;
+				else if (c2 == nshape + 2)  v2 = Scale * t2B;
+				else if (c2 == nshape + 3)  v2 = Scale * t3B;
+				else if (c2 == nc + 1)      v2 = brB * dphp1;
+				else if (c2 == nc + 2)      v2 = brB * dphp2;
+				else if (c2 == nc + 3)      v2 = brB * dphp3;
+				else if (c2 == ma - 1)      v2 = Scale * t4B * cl;
+				else                        v2 = Scale * t5B;
 
-            for (j = 1; j < incl_count; j++)
-            {
-                double l_dbr = dbr[j];
-                int l_incl = incl[j];
-                tmp += l_dbr * CUDA_Dg[m + l_incl];
-                if ((i + 1) <= ncoef0)
-                {
-                    tmp1 += l_dbr * CUDA_Dg[m1 + l_incl];
-                }
-            }
+				if (c1 >= iStart && c1 <= ma) { row[c1] = v1; if (c1 >= 2) dave1 += v1; }
+				if (c2 <= ma) { row[c2] = v2; dave2 += v2; }
+				if (tid == 0) ytemp[jp + 1] = ymod;
+				lave += ymod;
+			}
 
-            (*CUDA_LCC).dytemp[d] = Scale * tmp;
-            if ((i + 1) <= ncoef0)
-            {
-                (*CUDA_LCC).dytemp[d1] = Scale * tmp1;
-            }
-        }
-    }
-    else
-    {
-        for (i = 1; i <= ncoef0; i++, d += Lpoints1)
-            (*CUDA_LCC).dytemp[d] = 0;
-    }
+			/* geo[]/wc/fc are re-written next pass; every lane must be done
+			   reading them (lanes run independently since Volta) */
+			__syncwarp();
+		} /* jp pair */
+	} /* geometry batch */
 
-    return(0);
+	if (Inrel == 1)
+	{
+		/* per-lane column sums ARE the dave entries (rows 2..ma) */
+		if (c1 >= 2 && c1 <= ma) (*CUDA_LCC).dave[c1] = dave1;
+		if (c2 <= ma) (*CUDA_LCC).dave[c2] = dave2;
+	}
+	if (tid == 0)
+	{
+		(*CUDA_LCC).np = lnp0 + Lpoints;
+		if (Inrel == 1)
+			(*CUDA_LCC).ave = lave;
+	}
+	__syncwarp();
 }

--- a/period_search_cuda/period_search/curv.cu
+++ b/period_search_cuda/period_search/curv.cu
@@ -10,7 +10,7 @@
 
 __device__ void curv(freq_context *CUDA_LCC,double cg[],int brtmpl,int brtmph)
 {
-   int i, m, n, l, k;
+   int i, m, n, l;
    
    double fsum,
           g;
@@ -34,9 +34,8 @@ __device__ void curv(freq_context *CUDA_LCC,double cg[],int brtmpl,int brtmph)
         }
       g = exp(g);
       (*CUDA_LCC).Area[i] = CUDA_Darea[i] * g;
-      for (k = 1; k <= n; k++)
-         (*CUDA_LCC).Dg[i+k*(CUDA_Numfac1)] = g * CUDA_Dsph[i][k];
-
+      /* Dg is no longer materialized: Dg[i][k] == g * CUDA_Dsph[i][k] is
+	 folded into the facet weights via Area (= Darea * g) - see bright.cu */
    }
    __syncthreads();
 }

--- a/period_search_cuda/period_search/curve2_CUDA.cu
+++ b/period_search_cuda/period_search/curve2_CUDA.cu
@@ -9,265 +9,274 @@
 //#include <cuda_runtime.h>
 #include <device_launch_parameters.h>
 
+/* 2026 rewrite: the normal equations are accumulated once per CURVE2_K-point
+   tile (a rank-K update computed from shared memory) instead of once per data
+   point. The old code did, for every point, a read-modify-write sweep of the
+   whole triangular alpha matrix in global memory - by far the largest memory
+   stream of the application after Dg. Staging reads dytemp coalesced (it is
+   stored transposed, see bright.cu) and the relative-lightcurve
+   renormalization is folded into the staging, which removes one more full
+   read+write pass over dytemp.
+
+   One warp per block. The two branches below reproduce the original
+   MrqcofCurve2's absolute (ia[1]!=0) and relative (ia[1]==0) address
+   arithmetic element for element; within a tile only the summation order over
+   the K points changes (a+b+c+d... becomes one fused sum), which is the usual
+   reordering freedom.
+
+   T[p][l] holds the staged dyda of point p, 1-based parameter row l. Tiles
+   past the end of the lightcurve are zero-filled so they add exact zeros. */
+
 __device__ void MrqcofCurve2(freq_context* CUDA_LCC, double* alpha, double beta[], int inrel, int lpoints)
 {
-  int l, jp, j, k, m, lnp1, lnp2, Lpoints1 = lpoints + 1;
-  double dy, sig2i, wt, ymod, coef1, coef, wght, ltrial_chisq;
-  //int2 xx;
+  const int tid = threadIdx.x;
+  curve2share* __restrict__ shw = &mrq_share_block()->c2;
+  double (* __restrict__ T)[DYT_STRIDE] = shw->T;
+  double* __restrict__ s2w = shw->s2w;
+  double* __restrict__ dws = shw->dws;
 
+  const int ma = CUDA_ma;
+  const int mfit1 = CUDA_mfit1;
+  const int lastone = CUDA_lastone, lastma = CUDA_lastma;
+  double* __restrict__ dytemp = (*CUDA_LCC).dytemp;
+  double* __restrict__ ytemp = (*CUDA_LCC).ytemp;
 
-  //precalc thread boundaries
-  int tmph, tmpl;
-  tmph = lpoints / CUDA_BLOCK_DIM;
-  if (lpoints % CUDA_BLOCK_DIM) tmph++;
-  tmpl = threadIdx.x * tmph;
-  lnp1 = (*CUDA_LCC).np1 + tmpl;
-  tmph = tmpl + tmph;
-  if (tmph > lpoints) tmph = lpoints;
-  tmpl++;
+  const int lnp1base = (*CUDA_LCC).np1;
+  const int lnp2base = (*CUDA_LCC).np2;
+  const double ave = (*CUDA_LCC).ave;
+  double ltrial_chisq = (*CUDA_LCC).trial_chisq;
 
-  int matmph, matmpl;
-  matmph = CUDA_ma / CUDA_BLOCK_DIM;
-  if (CUDA_ma % CUDA_BLOCK_DIM) matmph++;
-  matmpl = threadIdx.x * matmph;
-  matmph = matmpl + matmph;
-  if (matmph > CUDA_ma) matmph = CUDA_ma;
-  matmpl++;
+  const int j1 = 1 + tid;   /* parameter rows owned by this lane */
+  const int j2 = 33 + tid;
 
-  int latmph, latmpl;
-  latmph = CUDA_lastone / CUDA_BLOCK_DIM;
-  if (CUDA_lastone % CUDA_BLOCK_DIM) latmph++;
-  latmpl = threadIdx.x * latmph;
-  latmph = latmpl + latmph;
-  if (latmph > CUDA_lastone) latmph = CUDA_lastone;
-  latmpl++;
-
-  /*   if ((*CUDA_LCC).Lastcall != 1) always ==0
-       {*/
-  if (inrel /*==1*/)
+#pragma unroll 1
+  for (int jp0 = 1; jp0 <= lpoints; jp0 += CURVE2_K)
     {
-      for (jp = tmpl; jp <= tmph; jp++)
+      int P = lpoints - jp0 + 1;
+      if (P > CURVE2_K) P = CURVE2_K;
+
+      /* ---- stage the tile (lanes = parameters, coalesced reads) ---- */
+#pragma unroll 1
+      for (int p = 0; p < CURVE2_K; p++)
 	{
-	  lnp1++;
-	  int ixx = jp + 1 * Lpoints1;
-	  /* Set the size scale coeff. deriv. explicitly zero for relative lcurves */
-	  (*CUDA_LCC).dytemp[ixx] = 0;
-
-	  //xx = tex1Dfetch(texsig, lnp1);
-	  //coef = __hiloint2double(xx.y, xx.x) * lpoints / (*CUDA_LCC).ave;
-	  coef = CUDA_sig[lnp1] * lpoints / (*CUDA_LCC).ave;
-
-	  double yytmp = (*CUDA_LCC).ytemp[jp];
-	  coef1 = yytmp / (*CUDA_LCC).ave;
-	  (*CUDA_LCC).ytemp[jp] = coef * yytmp;
-
-	  ixx += Lpoints1;
-	  for (l = 2; l <= CUDA_ma; l++, ixx += Lpoints1)
-	    (*CUDA_LCC).dytemp[ixx] = coef * ((*CUDA_LCC).dytemp[ixx] - coef1 * (*CUDA_LCC).dave[l]);
+	  double r1 = 0.0, r2 = 0.0;
+	  if (p < P)
+	    {
+	      const int jp = jp0 + p;
+	      double const* __restrict__ row = dytemp + (size_t)(jp - 1) * DYT_STRIDE;
+	      if (inrel)
+		{
+		  /* renormalization for relative lightcurves, folded in;
+		     same arithmetic as the old in-place pass */
+		  double yytmp = ytemp[jp];
+		  double coef = CUDA_sig[lnp1base + jp] * lpoints / ave;
+		  double coef1 = yytmp / ave;
+		  if (j1 >= 2 && j1 <= ma)
+		    r1 = coef * (row[j1] - coef1 * (*CUDA_LCC).dave[j1]);
+		  if (j2 <= ma)
+		    r2 = coef * (row[j2] - coef1 * (*CUDA_LCC).dave[j2]);
+		  /* j1 == 1: the size-scale derivative is explicitly zero */
+		}
+	      else
+		{
+		  if (j1 <= ma) r1 = row[j1];
+		  if (j2 <= ma) r2 = row[j2];
+		}
+	    }
+	  T[p][j1] = r1;
+	  T[p][j2] = r2;
 	}
-    }
-  __syncthreads();
+      __syncwarp();
 
-  if (threadIdx.x == 0)
-    {
-      (*CUDA_LCC).np1 += lpoints;
-    }
-
-  lnp2 = (*CUDA_LCC).np2;
-  ltrial_chisq = (*CUDA_LCC).trial_chisq;
-
-  if (CUDA_ia[1]) //not relative
-    {
-      for (jp = 1; jp <= lpoints; jp++)
+      /* ---- per-point scalars, ascending jp to keep the chisq order ---- */
+#pragma unroll 1
+      for (int p = 0; p < CURVE2_K; p++)
 	{
-	  ymod = (*CUDA_LCC).ytemp[jp];
-
-	  int ixx = jp + matmpl * Lpoints1;
-	  for (l = matmpl; l <= matmph; l++, ixx += Lpoints1)
-	    (*CUDA_LCC).dyda[l] = (*CUDA_LCC).dytemp[ixx];
-	  __syncthreads();
-
-	  lnp2++;
-			
-	  //xx = tex1Dfetch(texsig, lnp2);
-	  //sig2i = 1 / (__hiloint2double(xx.y, xx.x) * __hiloint2double(xx.y, xx.x));
-	  sig2i = 1 / (CUDA_sig[lnp2] * CUDA_sig[lnp2]);
-
-	  //xx = tex1Dfetch(texWeight, lnp2);
-	  //wght = __hiloint2double(xx.y, xx.x);
-	  wght = CUDA_Weight[lnp2];
-
-	  //xx = tex1Dfetch(texbrightness, lnp2);
-	  //dy = __hiloint2double(xx.y, xx.x) - ymod;
-	  dy = CUDA_brightness[lnp2] - ymod;
-
-	  j = 0;
-	  //
-	  double sig2iwght = sig2i * wght;
-	  //
-	  for (l = 1; l <= CUDA_lastone; l++)
+	  double s2wv = 0.0, dyv = 0.0;
+	  if (p < P)
 	    {
-	      j++;
-	      wt = (*CUDA_LCC).dyda[l] * sig2iwght;
-	      //				   k = 0;
-	      //precalc thread boundaries
-	      tmph = l / CUDA_BLOCK_DIM;
-	      if (l % CUDA_BLOCK_DIM) tmph++;
-	      tmpl = threadIdx.x * tmph;
-	      tmph = tmpl + tmph;
-	      if (tmph > l) tmph = l;
-	      tmpl++;
-	      for (m = tmpl; m <= tmph; m++)
+	      const int jp = jp0 + p;
+	      const int lnp2 = lnp2base + jp;
+	      double ymod;
+	      if (inrel)
 		{
-		  //				  k++;
-		  alpha[j * (CUDA_mfit1)+m] = alpha[j * (CUDA_mfit1)+m] + wt * (*CUDA_LCC).dyda[m];
-		} /* m */
-	      __syncthreads();
-	      if (threadIdx.x == 0)
-		{
-		  beta[j] = beta[j] + dy * wt;
+		  double coef = CUDA_sig[lnp1base + jp] * lpoints / ave;
+		  ymod = coef * ytemp[jp];
 		}
-	      __syncthreads();
-	    } /* l */
-	  for (; l <= CUDA_lastma; l++)
+	      else
+		ymod = ytemp[jp];
+	      double sig2i = 1 / (CUDA_sig[lnp2] * CUDA_sig[lnp2]);
+	      double wght = CUDA_Weight[lnp2];
+	      dyv = CUDA_brightness[lnp2] - ymod;
+	      s2wv = sig2i * wght;
+	      ltrial_chisq = ltrial_chisq + dyv * dyv * s2wv;
+	    }
+	  if (tid == 0)
 	    {
-	      if (CUDA_ia[l])
-		{
-		  j++;
-		  wt = (*CUDA_LCC).dyda[l] * sig2iwght;
-		  //				   k = 0;
+	      s2w[p] = s2wv;
+	      dws[p] = dyv * s2wv;
+	    }
+	}
+      __syncwarp();
 
-		  for (m = latmpl; m <= latmph; m++)
-		    {
-		      //					  k++;
-		      alpha[j * (CUDA_mfit1)+m] = alpha[j * (CUDA_mfit1)+m] + wt * (*CUDA_LCC).dyda[m];
-		    } /* m */
-		  __syncthreads();
-		  if (threadIdx.x == 0)
-		    {
-		      k = CUDA_lastone;
-		      m = CUDA_lastone + 1;
-		      for (; m <= l; m++)
-			{
-			  if (CUDA_ia[m])
-			    {
-			      k++;
-			      alpha[j * (CUDA_mfit1)+k] = alpha[j * (CUDA_mfit1)+k] + wt * (*CUDA_LCC).dyda[m];
-			    }
-			} /* m */
-		      beta[j] = beta[j] + dy * wt;
-		    }
-		  __syncthreads();
-		}
-	    } /* l */
-	  ltrial_chisq = ltrial_chisq + dy * dy * sig2iwght;
-	} /* jp */
-    }
-  else //relative ia[1]==0
-    {
-      for (jp = 1; jp <= lpoints; jp++)
+      /* ---- rank-K triangular update, both original variants ---- */
+      if (CUDA_ia[1]) /* absolute: rows l = 1..lastone, alpha[l*mfit1 + m], m = 1..l */
 	{
-	  ymod = (*CUDA_LCC).ytemp[jp];
-
-	  int ixx = jp + matmpl * Lpoints1;
-	  for (l = matmpl; l <= matmph; l++, ixx += Lpoints1)
-	    (*CUDA_LCC).dyda[l] = (*CUDA_LCC).dytemp[ixx];
-	  __syncthreads();
-
-	  lnp2++;
-
-	  //xx = tex1Dfetch(texsig, lnp2);
-	  //sig2i = 1 / (__hiloint2double(xx.y, xx.x) * __hiloint2double(xx.y, xx.x));
-	  sig2i = 1 / (CUDA_sig[lnp2] * CUDA_sig[lnp2]);
-
-	  //xx = tex1Dfetch(texWeight, lnp2);
-	  //wght = __hiloint2double(xx.y, xx.x);
-	  wght = CUDA_Weight[lnp2];
-
-	  //xx = tex1Dfetch(texbrightness, lnp2);
-	  //dy = __hiloint2double(xx.y, xx.x) - ymod;
-	  dy = CUDA_brightness[lnp2] - ymod;
-
-	  j = 0;
-	  //
-	  double sig2iwght = sig2i * wght;
-	  //l==1
-	  //
-	  for (l = 2; l <= CUDA_lastone; l++)
+#pragma unroll 1
+	  for (int l = 1; l <= lastone; l++)
 	    {
+	      double w[CURVE2_K];
+#pragma unroll
+	      for (int p = 0; p < CURVE2_K; p++)
+		w[p] = T[p][l] * s2w[p];
+
+	      double* __restrict__ alphrow = alpha + l * mfit1;
+#pragma unroll 1
+	      for (int m = 1 + tid; m <= l; m += 32)
+		{
+		  double acc = 0.0;
+#pragma unroll
+		  for (int p = 0; p < CURVE2_K; p++)
+		    acc += w[p] * T[p][m];
+		  alphrow[m] = alphrow[m] + acc;
+		}
+	      if (tid == 0)
+		{
+		  double b = 0.0;
+#pragma unroll
+		  for (int p = 0; p < CURVE2_K; p++)
+		    b += dws[p] * T[p][l];
+		  beta[l] = beta[l] + b;
+		}
+	    }
+	  /* gated tail rows (lastone < l <= lastma), j counts gated rows */
+	  int j = lastone;
+#pragma unroll 1
+	  for (int l = lastone + 1; l <= lastma; l++)
+	    {
+	      if (!CUDA_ia[l]) continue;
 	      j++;
-	      wt = (*CUDA_LCC).dyda[l] * sig2iwght;
-	      //				   k = 0;
-	      //precalc thread boundaries
-	      tmph = l / CUDA_BLOCK_DIM;
-	      if (l % CUDA_BLOCK_DIM) tmph++;
-	      tmpl = threadIdx.x * tmph;
-	      tmph = tmpl + tmph;
-	      if (tmph > l) tmph = l;
-	      tmpl++;
-	      //m==1
-	      if (tmpl == 1) tmpl++;
-	      //
-	      for (m = tmpl; m <= tmph; m++)
-		{
-		  //					  k++;
-		  alpha[j * (CUDA_mfit1)+m - 1] = alpha[j * (CUDA_mfit1)+m - 1] + wt * (*CUDA_LCC).dyda[m];
-		} /* m */
-	      __syncthreads();
-	      if (threadIdx.x == 0)
-		{
-		  beta[j] = beta[j] + dy * wt;
-		}
-	      __syncthreads();
-	    } /* l */
-	  for (; l <= CUDA_lastma; l++)
-	    {
-	      if (CUDA_ia[l])
-		{
-		  j++;
-		  wt = (*CUDA_LCC).dyda[l] * sig2iwght;
-		  //				   k = 0;
+	      double w[CURVE2_K];
+#pragma unroll
+	      for (int p = 0; p < CURVE2_K; p++)
+		w[p] = T[p][l] * s2w[p];
 
-		  tmpl = latmpl;
-		  //m==1
-		  if (tmpl == 1) tmpl++;
-		  //
-		  for (m = tmpl; m <= latmph; m++)
+	      double* __restrict__ alphrow = alpha + j * mfit1;
+#pragma unroll 1
+	      for (int m = 1 + tid; m <= lastone; m += 32)
+		{
+		  double acc = 0.0;
+#pragma unroll
+		  for (int p = 0; p < CURVE2_K; p++)
+		    acc += w[p] * T[p][m];
+		  alphrow[m] = alphrow[m] + acc;
+		}
+	      if (tid == 0)
+		{
+		  int k = lastone;
+		  for (int m = lastone + 1; m <= l; m++)
 		    {
-		      //k++;
-		      alpha[j * (CUDA_mfit1)+m - 1] = alpha[j * (CUDA_mfit1)+m - 1] + wt * (*CUDA_LCC).dyda[m];
-		    } /* m */
-		  __syncthreads();
-		  if (threadIdx.x == 0)
-		    {
-		      k = CUDA_lastone - 1;
-		      m = CUDA_lastone + 1;
-		      for (; m <= l; m++)
+		      if (CUDA_ia[m])
 			{
-			  if (CUDA_ia[m])
-			    {
-			      k++;
-			      alpha[j * (CUDA_mfit1)+k] = alpha[j * (CUDA_mfit1)+k] + wt * (*CUDA_LCC).dyda[m];
-			    }
-			} /* m */
-		      beta[j] = beta[j] + dy * wt;
+			  k++;
+			  double acc = 0.0;
+#pragma unroll
+			  for (int p = 0; p < CURVE2_K; p++)
+			    acc += w[p] * T[p][m];
+			  alphrow[k] = alphrow[k] + acc;
+			}
 		    }
-		  __syncthreads();
+		  double b = 0.0;
+#pragma unroll
+		  for (int p = 0; p < CURVE2_K; p++)
+		    b += dws[p] * T[p][l];
+		  beta[j] = beta[j] + b;
 		}
-	    } /* l */
-	  ltrial_chisq = ltrial_chisq + dy * dy * sig2iwght;
-	} /* jp */
-    }
-  /*     } always ==0 /* Lastcall != 1 */
+	    }
+	}
+      else /* relative (ia[1]==0): rows l = 2..lastone, j = l-1, cols m-1 for m = 2..l */
+	{
+#pragma unroll 1
+	  for (int l = 2; l <= lastone; l++)
+	    {
+	      double w[CURVE2_K];
+#pragma unroll
+	      for (int p = 0; p < CURVE2_K; p++)
+		w[p] = T[p][l] * s2w[p];
 
-  /*  if (((*CUDA_LCC).Lastcall == 1) && (CUDA_Inrel[i] == 1)) always ==0
-      (*CUDA_LCC).Sclnw[i] = (*CUDA_LCC).Scale * CUDA_Lpoints[i] * CUDA_sig[np]/ave;*/
+	      double* __restrict__ alphrow = alpha + (l - 1) * mfit1;
+#pragma unroll 1
+	      for (int m = 2 + tid; m <= l; m += 32)
+		{
+		  double acc = 0.0;
+#pragma unroll
+		  for (int p = 0; p < CURVE2_K; p++)
+		    acc += w[p] * T[p][m];
+		  alphrow[m - 1] = alphrow[m - 1] + acc;
+		}
+	      if (tid == 0)
+		{
+		  double b = 0.0;
+#pragma unroll
+		  for (int p = 0; p < CURVE2_K; p++)
+		    b += dws[p] * T[p][l];
+		  beta[l - 1] = beta[l - 1] + b;
+		}
+	    }
+	  int j = lastone - 1;
+#pragma unroll 1
+	  for (int l = lastone + 1; l <= lastma; l++)
+	    {
+	      if (!CUDA_ia[l]) continue;
+	      j++;
+	      double w[CURVE2_K];
+#pragma unroll
+	      for (int p = 0; p < CURVE2_K; p++)
+		w[p] = T[p][l] * s2w[p];
 
-  if (threadIdx.x == 0)
+	      double* __restrict__ alphrow = alpha + j * mfit1;
+#pragma unroll 1
+	      for (int m = 2 + tid; m <= lastone; m += 32)
+		{
+		  double acc = 0.0;
+#pragma unroll
+		  for (int p = 0; p < CURVE2_K; p++)
+		    acc += w[p] * T[p][m];
+		  alphrow[m - 1] = alphrow[m - 1] + acc;
+		}
+	      if (tid == 0)
+		{
+		  int k = lastone - 1;
+		  for (int m = lastone + 1; m <= l; m++)
+		    {
+		      if (CUDA_ia[m])
+			{
+			  k++;
+			  double acc = 0.0;
+#pragma unroll
+			  for (int p = 0; p < CURVE2_K; p++)
+			    acc += w[p] * T[p][m];
+			  alphrow[k] = alphrow[k] + acc;
+			}
+		    }
+		  double b = 0.0;
+#pragma unroll
+		  for (int p = 0; p < CURVE2_K; p++)
+		    b += dws[p] * T[p][l];
+		  beta[j] = beta[j] + b;
+		}
+	    }
+	}
+      __syncwarp();
+    } /* jp0 */
+
+  if (tid == 0)
     {
-      (*CUDA_LCC).np2 = lnp2;
+      (*CUDA_LCC).np1 = lnp1base + lpoints;
+      (*CUDA_LCC).np2 = lnp2base + lpoints;
       (*CUDA_LCC).trial_chisq = ltrial_chisq;
     }
+  __syncwarp();
 }
 
 

--- a/period_search_cuda/period_search/declarations_CUDA.h
+++ b/period_search_cuda/period_search/declarations_CUDA.h
@@ -14,10 +14,8 @@ __device__ double mrqcof_end(freq_context *CUDA_LCC,  double *alpha);
 __device__ double mrqcof(freq_context *CUDA_LCC, double a[], int ia[], int ma,
                          double alpha[/*MAX_N_PAR+1*/][MAX_N_PAR+1], double beta[], int mfit, int lastone, int lastma);
 //__device__ int gauss_errc(freq_context *CUDA_LCC,int n, double b[]);
-extern __device__ int gauss_errc(freq_context *CUDA_LCC, int ma);
+extern __device__ int gauss_errc_shared(freq_context *CUDA_LCC, int ma);
 __device__ void blmatrix(freq_context *CUDA_LCC,double bet, double lam);
-__device__ double conv(freq_context *CUDA_LCC,int nc,int tmpl,int tmph,int brtmpl,int brtmph);
-__device__ double bright(freq_context *CUDA_LCC,double cg[],int jp,int Lpoints1,int Inrel);
-__device__ void matrix_neo(freq_context *CUDA_LCC, double cg[],int lnp1, int Lpoints);
+__device__ void bright_curve1_warp(freq_context *CUDA_LCC, double const *a, int Inrel, int Lpoints);
 __global__ void CudaCalculateIter1Mrqcof2Curve2(int inrel,int lpoints);
 __global__ void CudaCalculateIter1Mrqcof1Curve2(int inrel,int lpoints);

--- a/period_search_cuda/period_search/gauss_errc.cu
+++ b/period_search_cuda/period_search/gauss_errc.cu
@@ -1,167 +1,186 @@
-#define SWAP(a,b) {temp=(a);(a)=(b);(b)=temp;}
+/* from Numerical Recipes
 
-#include <math.h>
+   8.11.2006
+
+   2026: the damped normal matrix is staged into dynamic shared memory and the
+   Gauss-Jordan elimination runs entirely there, one block (CUDA_BLOCK_DIM
+   threads) per frequency-pole pair. The old version worked on the matrix in
+   global memory: ~mfit full read+write sweeps of a ~25 KB matrix per solve
+   made it DRAM-bound. Two consequences of the caller's structure are used:
+
+   * the inverted matrix itself is dead - mrqcof_start rezeroes covar before
+	 mrqcof2 accumulates into it, and mrqmin_2_end copies that fresh
+	 accumulation - so neither the solved matrix nor the final
+	 column-unscramble pass of the classic routine is needed; only da (the
+	 step) and the return code leave this function;
+
+   * pivot selection order matches the original except for exact |value| ties
+	 across the different scan partitioning.
+
+   The caller passes the shared-memory size:
+   (mfit1*(mfit1|1) + mfit1 + 1) * sizeof(double). */
+
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
 #include "globals_CUDA.h"
-#include "declarations_CUDA.h"
-#include <cuda_runtime.h>
 #include <device_launch_parameters.h>
 
-//__device__ int gauss_errc(freq_context *CUDA_LCC,int n, double b[])
-__device__ int gauss_errc(freq_context* CUDA_LCC, const int ma)
+__device__ int gauss_errc_shared(freq_context* CUDA_LCC, const int ma)
 {
-	__shared__ int icol;
-	__shared__ double pivinv;
-	__shared__ int sh_icol[CUDA_BLOCK_DIM];
-	__shared__ int sh_irow[CUDA_BLOCK_DIM];
+	const int mf = CUDA_mfit;
+	const int mf1 = CUDA_mfit1;
+	const int tid = threadIdx.x;
+	const int nthreads = blockDim.x;
+	const int stride = mf1 | 1; /* odd stride: conflict-free column walks */
+
+	extern __shared__ double sh[];
+	double* __restrict__ cov = sh;                        /* [mf1][stride], row 0 unused */
+	double* __restrict__ das = sh + (size_t)mf1 * stride; /* [mf1] */
+
 	__shared__ double sh_big[CUDA_BLOCK_DIM];
+	__shared__ short sh_irow[CUDA_BLOCK_DIM], sh_icol[CUDA_BLOCK_DIM];
+	__shared__ short ipiv[DYT_STRIDE];
+	__shared__ double pivinv_s;
+	__shared__ int icol_s, irow_s, err_s;
 
-	//	__shared__ int indxc[MAX_N_PAR+1],indxr[MAX_N_PAR+1],ipiv[MAX_N_PAR+1];
-	int i, licol = 0, irow = 0, j, k, l, ll;
-	double big, dum, temp;
-	int n = CUDA_mfit;
+	const double damp = 1 + (*CUDA_LCC).Alamda;
 
-	int brtmph, brtmpl;
-	brtmph = n / CUDA_BLOCK_DIM;
-	if (n % CUDA_BLOCK_DIM) brtmph++;
-	brtmpl = threadIdx.x * brtmph;
-	brtmph = brtmpl + brtmph;
-	if (brtmph > n) brtmph = n;
-	brtmpl++;
-
-	/*        indxc=vector_int(n+1);
-		indxr=vector_int(n+1);
-		ipiv=vector_int(n+1);*/
-
-	if (threadIdx.x == 0)
+	/* stage the damped normal matrix; covar never touches global memory */
+	for (int x = mf1 + 1 + tid; x < mf1 * mf1; x += nthreads)
 	{
-		for (j = 1; j <= n; j++) (*CUDA_LCC).ipiv[j] = 0;
+		const int j = x / mf1, k = x - j * mf1;
+		if (k == 0) continue; /* column 0 is never read */
+		double v = (*CUDA_LCC).alpha[x];
+		if (j == k) v *= damp;
+		cov[j * stride + k] = v;
 	}
+	for (int x = 1 + tid; x <= mf; x += nthreads)
+	{
+		das[x] = (*CUDA_LCC).beta[x];
+		ipiv[x] = 0;
+	}
+	if (tid == 0) err_s = 0;
 	__syncthreads();
 
-	for (i = 1; i <= n; i++)
+	for (int i = 1; i <= mf; i++)
 	{
-		big = 0.0;
-		irow = 0;
-		licol = 0;
-		for (j = brtmpl; j <= brtmph; j++)
-			if ((*CUDA_LCC).ipiv[j] != 1)
-			{
-				int ixx = j * (CUDA_mfit1)+1;
-				for (k = 1; k <= n; k++, ixx++)
-				{
-					if ((*CUDA_LCC).ipiv[k] == 0)
-					{
-						double tmpcov = fabs((*CUDA_LCC).covar[ixx]);
-						if (tmpcov >= big)
-						{
-							big = tmpcov;
-							irow = j;
-							licol = k;
-						}
-					}
-					else if ((*CUDA_LCC).ipiv[k] > 1)
-					{
-						//printf("-");
-						__syncthreads();
-						/*					        deallocate_vector((void *) ipiv);
-												deallocate_vector((void *) indxc);
-												deallocate_vector((void *) indxr);*/
-						return(1);
-					}
-				}
-			}
-		sh_big[threadIdx.x] = big;
-		sh_irow[threadIdx.x] = irow;
-		sh_icol[threadIdx.x] = licol;
-		__syncthreads();
-		if (threadIdx.x == 0)
+		/* full-pivot search: thread j scans row j */
+		double big = 0.0;
+		int irow = 0, licol = 0;
+		const int j = 1 + tid;
+		if (j <= mf && ipiv[j] != 1)
 		{
-			big = sh_big[0];
-			icol = sh_icol[0];
-			irow = sh_irow[0];
-			for (j = 1; j < CUDA_BLOCK_DIM; j++)
+			double const* __restrict__ rowp = cov + j * stride;
+			for (int k = 1; k <= mf; k++)
 			{
-				if (sh_big[j] >= big)
+				const int ii = ipiv[k];
+				if (ii == 0)
 				{
-					big = sh_big[j];
-					irow = sh_irow[j];
-					icol = sh_icol[j];
-				}
-			}
-			++((*CUDA_LCC).ipiv[icol]);
-			if (irow != icol)
-			{
-				for (l = 1; l <= n; l++)
-				{
-					SWAP((*CUDA_LCC).covar[irow * (CUDA_mfit1)+l], (*CUDA_LCC).covar[icol * (CUDA_mfit1)+l])
-				}
-
-				SWAP((*CUDA_LCC).da[irow], (*CUDA_LCC).da[icol])
-					//SWAP(b[irow],b[icol])
-			}
-			(*CUDA_LCC).indxr[i] = irow;
-			(*CUDA_LCC).indxc[i] = icol;
-			if ((*CUDA_LCC).covar[icol * (CUDA_mfit1)+icol] == 0.0)
-			{
-				j = 0;
-				for (int l = 1; l <= ma; l++)
-				{
-					if (CUDA_ia[l])
+					const double t = fabs(rowp[k]);
+					if (t >= big)
 					{
-						j++;
-						(*CUDA_LCC).atry[l] = (*CUDA_LCC).cg[l] + (*CUDA_LCC).da[j];
+						big = t;
+						irow = j;
+						licol = k;
 					}
 				}
-				//printf("+");
-				/*					    deallocate_vector((void *) ipiv);
-												deallocate_vector((void *) indxc);
-												deallocate_vector((void *) indxr);*/
-				return(2);
+				else if (ii > 1)
+					err_s = 1; /* all writers store the same value */
 			}
-			pivinv = 1.0 / (*CUDA_LCC).covar[icol * (CUDA_mfit1)+icol];
-			(*CUDA_LCC).covar[icol * (CUDA_mfit1)+icol] = 1.0;
-			(*CUDA_LCC).da[icol] *= pivinv;
-			//b[icol] *= pivinv;
+		}
+		sh_big[tid] = big;
+		sh_irow[tid] = (short)irow;
+		sh_icol[tid] = (short)licol;
+		__syncthreads();
+
+		if (err_s)
+			break;
+
+		if (tid == 0)
+		{
+			double b = sh_big[0];
+			int ir = sh_irow[0], ic = sh_icol[0];
+			for (int t = 1; t < nthreads; t++)
+				if (sh_big[t] >= b)
+				{
+					b = sh_big[t];
+					ir = sh_irow[t];
+					ic = sh_icol[t];
+				}
+			ipiv[ic] += 1;
+			icol_s = ic;
+			irow_s = ir;
 		}
 		__syncthreads();
 
-		for (l = brtmpl; l <= brtmph; l++)
+		const int icol = icol_s;
+		const int irowg = irow_s;
+
+		if (irowg != icol)
 		{
-			(*CUDA_LCC).covar[icol * (CUDA_mfit1)+l] *= pivinv;
+			for (int l = 1 + tid; l <= mf; l += nthreads)
+			{
+				const double t = cov[irowg * stride + l];
+				cov[irowg * stride + l] = cov[icol * stride + l];
+				cov[icol * stride + l] = t;
+			}
+			if (tid == 0)
+			{
+				const double t = das[irowg];
+				das[irowg] = das[icol];
+				das[icol] = t;
+			}
 		}
 		__syncthreads();
 
-		for (ll = brtmpl; ll <= brtmph; ll++)
-			if (ll != icol)
+		const double piv = cov[icol * stride + icol];
+		if (piv == 0.0)
+		{
+			if (tid == 0) err_s = 2;
+			__syncthreads();
+			break;
+		}
+
+		if (tid == 0)
+		{
+			const double pv = 1.0 / piv;
+			pivinv_s = pv;
+			cov[icol * stride + icol] = 1.0;
+			das[icol] *= pv;
+		}
+		__syncthreads();
+		const double pivinv = pivinv_s;
+
+		for (int x = 1 + tid; x <= mf; x += nthreads)
+			cov[icol * stride + x] *= pivinv;
+		__syncthreads();
+
+		/* eliminate all other rows: warp per row, lanes over columns */
+		const int wid = tid >> 5, lane = tid & 31, nwarps = nthreads >> 5;
+		for (int ll = 1 + wid; ll <= mf; ll += nwarps)
+		{
+			if (ll == icol) continue;
+			const double dum = cov[ll * stride + icol];
+			__syncwarp();
+			double const* __restrict__ prow = cov + icol * stride;
+			double* __restrict__ lrow = cov + ll * stride;
+			for (int c = 1 + lane; c <= mf; c += 32)
 			{
-				int ixx = ll * (CUDA_mfit1), jxx = icol * (CUDA_mfit1);
-				dum = (*CUDA_LCC).covar[ixx + icol];
-				(*CUDA_LCC).covar[ixx + icol] = 0.0;
-				ixx++;
-				jxx++;
-				for (l = 1; l <= n; l++, ixx++, jxx++) (*CUDA_LCC).covar[ixx] -= (*CUDA_LCC).covar[jxx] * dum;
-				(*CUDA_LCC).da[ll] -= (*CUDA_LCC).da[icol] * dum;
-				//b[ll] -= b[icol]*dum;
+				const double base = (c == icol) ? 0.0 : lrow[c];
+				lrow[c] = base - prow[c] * dum;
 			}
+			if (lane == 0)
+				das[ll] -= das[icol] * dum;
+		}
 		__syncthreads();
 	}
-	if (threadIdx.x == 0)
-	{
-		for (l = n; l >= 1; l--)
-		{
-			if ((*CUDA_LCC).indxr[l] != (*CUDA_LCC).indxc[l])
-				for (k = 1; k <= n; k++)
-					SWAP((*CUDA_LCC).covar[k * (CUDA_mfit1)+(*CUDA_LCC).indxr[l]], (*CUDA_LCC).covar[k * (CUDA_mfit1)+(*CUDA_LCC).indxc[l]]);
-		}
-	}
+
+	/* the step vector goes back to global (mrqmin uses it for atry, and
+	   mrqmin_2_end copies it into beta on success) */
+	for (int x = 1 + tid; x <= mf; x += nthreads)
+		(*CUDA_LCC).da[x] = das[x];
 	__syncthreads();
-	/*        deallocate_vector((void *) ipiv);
-		deallocate_vector((void *) indxc);
-		deallocate_vector((void *) indxr);*/
 
-	return(0);
+	return err_s;
 }
-#undef SWAP
-/* from Numerical Recipes */

--- a/period_search_cuda/period_search/globals_CUDA.h
+++ b/period_search_cuda/period_search/globals_CUDA.h
@@ -145,3 +145,45 @@ struct freq_result
 };
 
 __device__ extern freq_result *CUDA_FR;
+
+/* ---- shared-memory staging for the 2026 warp-cooperative kernels ---- */
+
+/* transposed dytemp row stride: dytempT[(jp-1)*DYT_STRIDE + l], l = 1..ma.
+   Requires ma <= DYT_STRIDE-1 (spherical-harmonics degree <= 6, i.e. every
+   production workunit); enforced on the host. */
+#define DYT_STRIDE 64
+#define CURVE2_K 8
+#define GEOM_PT_SIZE 26
+#define GEO_BATCH 16
+
+#ifdef __CUDACC__
+struct brightshare
+{
+	double wcA[32];                     /* compacted facet weights, point A */
+	double wcB[32];                     /* compacted facet weights, point B */
+	int    fc[32];                      /* compacted facet indices */
+	double geo[GEO_BATCH][GEOM_PT_SIZE];/* per-point geometry */
+	double inv[11];                     /* per-curve invariants */
+};
+
+struct curve2share
+{
+	double T[CURVE2_K][DYT_STRIDE];     /* staged dyda tile, rows 1..ma */
+	double s2w[CURVE2_K];
+	double dws[CURVE2_K];
+};
+
+/* bright and curve2 never use their staging at the same time, so they share
+   one per-block union: the shared footprint is max(...), not the sum */
+union mrqshare
+{
+	brightshare b;
+	curve2share c2;
+};
+
+__device__ __forceinline__ mrqshare* mrq_share_block()
+{
+	__shared__ mrqshare s;
+	return &s;
+}
+#endif

--- a/period_search_cuda/period_search/mrqcof.cu
+++ b/period_search_cuda/period_search/mrqcof.cu
@@ -75,148 +75,94 @@ __device__ double mrqcof_end(freq_context *CUDA_LCC,double *alpha)
 
 __device__ void mrqcof_matrix(freq_context *CUDA_LCC, double a[], int Lpoints)
 {
-   matrix_neo(CUDA_LCC, a,(*CUDA_LCC).np, Lpoints);
+   /* geometry is computed inside bright_curve1_warp() since the 2026 rewrite */
 }
 
 __device__ void mrqcof_curve1(freq_context *CUDA_LCC, double a[],
 	      double *alpha, double beta[],int Inrel,int Lpoints)
 {
-	int l,k,jp, lnp,Lpoints1=Lpoints+1;
-   double lave;
-   __shared__ double tmave[CUDA_BLOCK_DIM];
-
-   lnp=(*CUDA_LCC).np;
-   lave=(*CUDA_LCC).ave;
-//precalc thread boundaries
-    int brtmph,brtmpl;
-	brtmph=Lpoints/CUDA_BLOCK_DIM;
-	if(Lpoints%CUDA_BLOCK_DIM) brtmph++;
-	brtmpl=threadIdx.x*brtmph;
-	brtmph=brtmpl+brtmph;
-	if (brtmph>Lpoints) brtmph=Lpoints;
-	brtmpl++;
-//
-
-   for (jp = brtmpl; jp <= brtmph; jp++)
-    bright(CUDA_LCC,a,jp,Lpoints1,Inrel);
-
-   __syncthreads();
-
-  if (Inrel == 1) {
-    int tmph,tmpl;
-	tmph=CUDA_ma/CUDA_BLOCK_DIM;
-	if(CUDA_ma%CUDA_BLOCK_DIM) tmph++;
-	tmpl=threadIdx.x*tmph;
-	tmph=tmpl+tmph;
-	if (tmph>CUDA_ma) tmph=CUDA_ma;
-	tmpl++;
-	if (tmpl==1) tmpl++;
-
-	  int ixx;
-	  ixx=tmpl*Lpoints1;
-	  for (l=tmpl; l <= tmph; l++)
-		{
-	  //jp==1
-			ixx++;
-			(*CUDA_LCC).dave[l] = (*CUDA_LCC).dytemp[ixx];
-      //jp>=2
-			ixx++;
-		   for (jp = 2; jp <= Lpoints; jp++,ixx++)
-		   {
-			(*CUDA_LCC).dave[l] = (*CUDA_LCC).dave[l] + (*CUDA_LCC).dytemp[ixx];
-		   }
-
-	  }
-		tmave[threadIdx.x] = 0;
-	   for (jp = brtmpl; jp <= brtmph; jp++) tmave[threadIdx.x] += (*CUDA_LCC).ytemp[jp];
-	   __syncthreads();
-//parallel reduction
-	   k=CUDA_BLOCK_DIM>>1;
-	   while (k>1)
-	   {
-		   if (threadIdx.x<k) tmave[threadIdx.x]+=tmave[threadIdx.x+k];
-		   k=k>>1;
-		   __syncthreads();
-	   }
-	   if (threadIdx.x==0) lave=tmave[0]+tmave[1];
-//parallel reduction end
-
-  }
-	  if (threadIdx.x==0)
-	  {
-	   (*CUDA_LCC).np=lnp+Lpoints;
-	   (*CUDA_LCC).ave=lave;
-	  }
+   /* warp-cooperative rewrite: geometry, brightness, derivatives, and the
+	  dave/ave sums are all produced by one warp in bright_curve1_warp()
+	  (see bright.cu). alpha/beta are untouched here - they are accumulated
+	  in MrqcofCurve2. */
+   bright_curve1_warp(CUDA_LCC, a, Inrel, Lpoints);
 }
 
 __device__ void mrqcof_curve1_last(freq_context *CUDA_LCC, double a[],
 	      double *alpha, double beta[],int Inrel,int Lpoints)
 {
-	int l,jp, lnp;
-   double ymod, lave;
+	/* the last "lightcurve" is the convexity regularization: brightness and
+	   derivatives depend only on Area and Dsph (all rotation/phase columns
+	   are zero, as in the old conv()). One warp per block; the Dg fold
+	   applies here too: Dg[i][l]*Darea[i]*Nor = Dsph[i][l]*(Area[i]*Nor). */
+	const int tid = threadIdx.x;
+	brightshare* __restrict__ shw = &mrq_share_block()->b;
+	double* __restrict__ ww = shw->wcA;
 
-   lnp=(*CUDA_LCC).np;
-   //
-   if (threadIdx.x==0)
-   {
-	   if (Inrel == 1) /* is the LC relative? */
-	   {
-		  lave = 0;
-		  for (l = 1; l <= CUDA_ma; l++)
-		  (*CUDA_LCC).dave[l]=0;
-	   }
-	   else
-		  lave=(*CUDA_LCC).ave;
-   }
-//precalc thread boundaries
-    int tmph,tmpl;
-	tmph=CUDA_ma/CUDA_BLOCK_DIM;
-	if(CUDA_ma%CUDA_BLOCK_DIM) tmph++;
-	tmpl=threadIdx.x*tmph;
-	tmph=tmpl+tmph;
-	if (tmph>CUDA_ma) tmph=CUDA_ma;
-	tmpl++;
-//
-    int brtmph,brtmpl;
-	brtmph=CUDA_Numfac/CUDA_BLOCK_DIM;
-	if(CUDA_Numfac%CUDA_BLOCK_DIM) brtmph++;
-	brtmpl=threadIdx.x*brtmph;
-	brtmph=brtmpl+brtmph;
-	if (brtmph>CUDA_Numfac) brtmph=CUDA_Numfac;
-	brtmpl++;
+	const int ma = CUDA_ma, nco = CUDA_Ncoef, nf = CUDA_Numfac;
+	double* __restrict__ dytemp = (*CUDA_LCC).dytemp;
+	double* __restrict__ ytemp = (*CUDA_LCC).ytemp;
+	double const* __restrict__ areap = &CUDA_Area[blockIdx.x * CUDA_Numfac1];
+	int lnp = (*CUDA_LCC).np;
+	double lave = (Inrel == 1) ? 0 : (*CUDA_LCC).ave;
 
-	__syncthreads();
+	const int c1 = 1 + tid, c2 = 33 + tid;
+	double dave1 = 0, dave2 = 0;
 
-
-      for (jp = 1; jp <= Lpoints; jp++)
-      {
-         lnp++;
-
-         ymod = conv(CUDA_LCC,jp-1,tmpl,tmph,brtmpl,brtmph);
-
-		 if (threadIdx.x==0)
-		 {
-			 (*CUDA_LCC).ytemp[jp] = ymod;
-
-			 if (Inrel == 1)
-				lave = lave + ymod;
-		 }
-		for (l=tmpl; l <= tmph; l++)
+#pragma unroll 1
+	for (int jp = 1; jp <= Lpoints; jp++)
+	{
+		lnp++;
+		double ym = 0, a1 = 0, a2 = 0;
+#pragma unroll 1
+		for (int f0 = 1; f0 <= nf; f0 += 32)
 		{
-			(*CUDA_LCC).dytemp[jp+l*(Lpoints+1)] = (*CUDA_LCC).dyda[l];
-			if (Inrel == 1)
-				(*CUDA_LCC).dave[l] = (*CUDA_LCC).dave[l] + (*CUDA_LCC).dyda[l];
+			const int i = f0 + tid;
+			double w = 0.0;
+			if (i <= nf)
+			{
+				w = areap[i] * CUDA_Nor[i][jp - 1];
+				ym += w;
+			}
+			ww[tid] = w;
+			__syncwarp();
+			int kend = nf - f0 + 1;
+			if (kend > 32) kend = 32;
+#pragma unroll 4
+			for (int k = 0; k < kend; k++)
+			{
+				double w2 = ww[k];
+				double const* __restrict__ row = CUDA_Dsph[f0 + k];
+				a1 += w2 * row[c1];
+				a2 += w2 * row[c2];
+			}
+			__syncwarp();
 		}
-		/* save lightcurves */
-		 __syncthreads();
+#pragma unroll
+		for (int off = 16; off > 0; off >>= 1)
+			ym += __shfl_xor_sync(0xffffffff, ym, off);
 
-/*         if ((*CUDA_LCC).Lastcall == 1) always ==0
-			 (*CUDA_LCC).Yout[np] = ymod;*/
-      } /* jp, lpoints */
-	 if (threadIdx.x==0)
-	 {
-		  (*CUDA_LCC).np=lnp;
-		  (*CUDA_LCC).ave=lave;
-	 }
+		double v1 = (c1 <= nco) ? a1 : 0.0;
+		double v2 = (c2 <= nco) ? a2 : 0.0;
+		double* __restrict__ row = dytemp + (size_t)(jp - 1) * DYT_STRIDE;
+		if (c1 <= ma) { row[c1] = v1; dave1 += v1; }
+		if (c2 <= ma) { row[c2] = v2; dave2 += v2; }
+		if (tid == 0) ytemp[jp] = ym;
+		if (Inrel == 1) lave += ym;
+		__syncwarp();
+	}
+
+	if (Inrel == 1)
+	{
+		/* the old code reset dave[] and accumulated the 3 points into it;
+		   the per-lane column sums are exactly that */
+		if (c1 <= ma) (*CUDA_LCC).dave[c1] = dave1;
+		if (c2 <= ma) (*CUDA_LCC).dave[c2] = dave2;
+	}
+	if (tid == 0)
+	{
+		(*CUDA_LCC).np = lnp;
+		(*CUDA_LCC).ave = lave;
+	}
+	__syncwarp();
 }
-

--- a/period_search_cuda/period_search/mrqmin.cu
+++ b/period_search_cuda/period_search/mrqmin.cu
@@ -40,20 +40,10 @@ __device__ int mrqmin_1_end(freq_context* CUDA_LCC, const int ma, const int mfit
 		__syncthreads();
 	}
 
-	for (j = brtmpl; j <= brtmph; j++)
-	{
-		int ixx = j * mfit1 + 1;
-		for (int k = 1; k <= CUDA_mfit; k++, ixx++)
-		{
-			(*CUDA_LCC).covar[ixx] = (*CUDA_LCC).alpha[ixx];
-		}
-
-		(*CUDA_LCC).covar[j * mfit1 + j] = (*CUDA_LCC).alpha[j * mfit1 + j] * (1 + (*CUDA_LCC).Alamda);
-		(*CUDA_LCC).da[j] = (*CUDA_LCC).beta[j];
-	}
-	__syncthreads();
-
-	int err_code = gauss_errc(CUDA_LCC, ma);
+	/* the damped matrix is staged straight from alpha into shared memory by
+	   the solver; covar is not touched (it is rezeroed by mrqcof_start before
+	   mrqcof2 accumulates into it) */
+	int err_code = gauss_errc_shared(CUDA_LCC, ma);
 	if(err_code)
 	{
 		return err_code;

--- a/period_search_cuda/period_search/start_CUDA.cu
+++ b/period_search_cuda/period_search/start_CUDA.cu
@@ -548,6 +548,9 @@ int CUDAPrepare(int cudadev, double* beta_pole, double* lambda_pole, double* par
 
 	//CUDA_grid_dim = 2 * deviceProp.multiProcessorCount * smxBlock;
 	CUDA_grid_dim = deviceProp.multiProcessorCount * smxBlock;
+	/* one block per (frequency, pole) pair: keep the grid a multiple of N_POLES */
+	CUDA_grid_dim = (CUDA_grid_dim / N_POLES) * N_POLES;
+	if (CUDA_grid_dim < N_POLES) CUDA_grid_dim = N_POLES;
 
 	if (!checkex)
 	{
@@ -831,14 +834,16 @@ int CUDAPrecalc(int cudadev, double freq_start, double freq_end, double freq_ste
 	//cudaMemcpyToSymbol(CUDA_ncoef0, &m, sizeof(m));
 	CopyValueToSymbol(CUDA_ncoef0, &m);                            // NOTE: So far OK ********************************************
 
-	int CUDA_Grid_dim_precalc = CUDA_grid_dim;
-	if (max_test_periods < CUDA_Grid_dim_precalc)
+	/* all (test period, pole) pairs run concurrently */
+	int precalcFreqs = CUDA_grid_dim / N_POLES;
+	if (max_test_periods < precalcFreqs)
 	{
-		CUDA_Grid_dim_precalc = max_test_periods;
+		precalcFreqs = max_test_periods;
 		//#ifdef _DEBUG
 		//		fprintf(stderr, "CUDA_Grid_dim_precalc = %d\n", CUDA_Grid_dim_precalc);
 		//#endif
 	}
+	const int CUDA_Grid_dim_precalc = precalcFreqs * N_POLES;
 
 	// safeCudaMalloc(d_CUDA_tim, tim.size());
 	//err = cudaMalloc(&pcc, CUDA_Grid_dim_precalc * sizeof(freq_context));
@@ -937,13 +942,13 @@ int CUDAPrecalc(int cudadev, double freq_start, double freq_end, double freq_ste
 
 	res = static_cast<freq_result*>(malloc(CUDA_Grid_dim_precalc * sizeof(freq_result)));
 
-	for (n = 1; n <= max_test_periods; n += CUDA_Grid_dim_precalc)
+	for (n = 1; n <= max_test_periods; n += precalcFreqs)
 	{
 		CudaCalculatePrepare<<<CUDA_Grid_dim_precalc, 1>>>(n, max_test_periods, freq_start, freq_step);
 		//err = cudaThreadSynchronize();
 		cudaDeviceSynchronize();
 
-		for (m = 1; m <= N_POLES; m++)
+		/* all N_POLES pole trials of this batch run concurrently as separate blocks */
 		{
 			//zero global End signal
 			theEnd = 0;
@@ -951,7 +956,7 @@ int CUDAPrecalc(int cudadev, double freq_start, double freq_end, double freq_ste
 			CopyValueToSymbol(CUDA_End, &theEnd);
 			//cudaGetSymbolAddress((void**)&endPtr, CUDA_End);
 			//
-			CudaCalculatePreparePole<<<CUDA_Grid_dim_precalc, 1>>>(m);
+			CudaCalculatePreparePole<<<CUDA_Grid_dim_precalc, 1>>>();
 			//
 #ifdef _DEBUG
 			printf(". ");
@@ -1028,10 +1033,23 @@ int CUDAPrecalc(int cudadev, double freq_start, double freq_end, double freq_ste
 		//read results here
 		handleCudaError(cudaMemcpy(res, pfr, sizeof(freq_result) * CUDA_Grid_dim_precalc, cudaMemcpyDeviceToHost), "cudaMemcpy", "pfr");
 
-		for (m = 1; m <= CUDA_Grid_dim_precalc; m++)
+		for (m = 0; m < precalcFreqs; m++)
 		{
-			if (res[m - 1].isReported == 1)
-				sum_dark_facet = sum_dark_facet + res[m - 1].dark_best;
+			/* best pole for this test period: smallest dev among the reported
+			   ones, mirroring the old serial per-pole update rule (NaN never
+			   wins a comparison, hence never gets selected) */
+			int best = -1, firstReported = -1;
+			for (auto p = 0; p < N_POLES; p++)
+			{
+				const auto b = m * N_POLES + p;
+				if (res[b].isReported != 1) continue;
+				if (firstReported < 0) firstReported = b;
+				if (!isnan(res[b].dev_best) && (best < 0 || res[b].dev_best < res[best].dev_best))
+					best = b;
+			}
+			if (best < 0) best = firstReported;
+			if (best >= 0)
+				sum_dark_facet = sum_dark_facet + res[best].dark_best;
 		}
 	} /* period loop */
 
@@ -1312,7 +1330,7 @@ int CUDAStart(int cudadev, int n_start_from, double freq_start, double freq_end,
 	//int firstreport = 0;//beta debug
 	auto oldFractionDone = 0.0001;
 
-	for (n = n_start_from; n <= n_max; n += CUDA_grid_dim)
+	for (n = n_start_from; n <= n_max; n += CUDA_grid_dim / N_POLES)
 	{
 		auto fractionDone = (double)n / (double)n_max;
 		//boinc_fraction_done(fractionDone);
@@ -1330,13 +1348,10 @@ int CUDAStart(int cudadev, int n_start_from, double freq_start, double freq_end,
 		//err = cudaThreadSynchronize();
 		//err = cudaDeviceSynchronize();
 
-		for (m = 1; m <= N_POLES; m++)
+		/* all N_POLES pole trials of this batch run concurrently as separate blocks */
 		{
 			auto mid = fractionDone - oldFractionDone;
-			auto inner = mid / static_cast<double>(N_POLES) * m;
-			//printf("mid: %.4f, inner: %.4f\n", mid, inner);
-			auto fractionDone2 = oldFractionDone + inner;
-			boinc_fraction_done(fractionDone2);
+			boinc_fraction_done(oldFractionDone);
 
 #ifdef _DEBUG
 			auto fraction2 = fractionDone2 * 100;
@@ -1352,7 +1367,7 @@ int CUDAStart(int cudadev, int n_start_from, double freq_start, double freq_end,
 			//cudaMemcpyToSymbol(CUDA_End, &theEnd, sizeof(theEnd));
 			CopyValueToSymbol(CUDA_End, &theEnd);
 			
-			CudaCalculatePreparePole<<<CUDA_grid_dim, 1>>>(m);
+			CudaCalculatePreparePole<<<CUDA_grid_dim, 1>>>();
 			//
 			while (!theEnd)
 			{
@@ -1395,6 +1410,7 @@ int CUDAStart(int cudadev, int n_start_from, double freq_start, double freq_end,
 				//handleCudaError(cudaMemcpyFromSymbolAsync(&theEnd, CUDA_End, sizeof theEnd, 0, cudaMemcpyDeviceToHost), "cudaMemcpyFromSymbolAsync", "theEnd");
 				CopyValueFromSymbol(&theEnd, CUDA_End);
 				cudaDeviceSynchronize();
+				boinc_fraction_done(oldFractionDone + mid * ((double)theEnd / CUDA_grid_dim));
 				theEnd = theEnd == CUDA_grid_dim;
 
 				//break;//debug
@@ -1416,17 +1432,33 @@ int CUDAStart(int cudadev, int n_start_from, double freq_start, double freq_end,
 
 		oldFractionDone = fractionDone;
 		LinesWritten = 0;
-		for (m = 1; m <= CUDA_grid_dim; m++)
+		for (m = 0; m < CUDA_grid_dim / N_POLES; m++)
 		{
-			if (res[m - 1].isReported == 1)
+			/* one output line per frequency: pick the best pole, i.e. the
+			   smallest dev among the reported ones. This mirrors the update
+			   rule of the old serial pole loop (dev_new < dev_best, so NaN
+			   never wins); if no pole produced a usable dev, fall back to the
+			   first reported one so the line count stays the same. */
+			int best = -1, firstReported = -1;
+			for (auto p = 0; p < N_POLES; p++)
+			{
+				const auto b = m * N_POLES + p;
+				if (res[b].isReported != 1) continue;
+				if (firstReported < 0) firstReported = b;
+				if (!isnan(res[b].dev_best) && (best < 0 || res[b].dev_best < res[best].dev_best))
+					best = b;
+			}
+			if (best < 0) best = firstReported;
+
+			if (best >= 0)
 			{
 				LinesWritten++;
-				double dark_best = n == 1 && m == 1
+				double dark_best = n == 1 && m == 0
 					? conw_r * escl * escl
-					: res[m - 1].dark_best;
+					: res[best].dark_best;
 
 				/* output file */
-				mf.printf("%.8f  %.6f  %.6f %4.1f %4.0f %4.0f\n", 24 * res[m - 1].per_best, res[m - 1].dev_best, res[m - 1].dev_best * res[m - 1].dev_best * (ndata - 3), dark_best, round(res[m - 1].la_best), round(res[m - 1].be_best));
+				mf.printf("%.8f  %.6f  %.6f %4.1f %4.0f %4.0f\n", 24 * res[best].per_best, res[best].dev_best, res[best].dev_best * res[best].dev_best * (ndata - 3), dark_best, round(res[best].la_best), round(res[best].be_best));
 			}
 		}
 

--- a/period_search_cuda/period_search/start_CUDA.cu
+++ b/period_search_cuda/period_search/start_CUDA.cu
@@ -822,6 +822,12 @@ int CUDAPrecalc(int cudadev, double freq_start, double freq_end, double freq_ste
 	CopyValueToSymbol(CUDA_ma, &ma);
 	CopyValueToSymbol(CUDA_mfit, &lmfit);
 
+	if (ma > DYT_STRIDE - 1)
+	{
+		fprintf(stderr, "Error: ma = %d exceeds the supported maximum of %d parameters (spherical-harmonics degree > 6)\n", ma, DYT_STRIDE - 1);
+		exit(3);
+	}
+	const size_t gaussShBytes = ((size_t)(lmfit + 1) * ((lmfit + 1) | 1) + lmfit + 2) * sizeof(double);
 	m = lmfit + 1;
 	//cudaMemcpyToSymbol(CUDA_mfit1, &m, sizeof(m));
 	//cudaMemcpyToSymbol(CUDA_lastma, &llastma, sizeof(llastma));
@@ -861,10 +867,7 @@ int CUDAPrecalc(int cudadev, double freq_start, double freq_end, double freq_ste
 	//cudaMemcpyToSymbol(CUDA_Dg_block, &m, sizeof(m));
 	CopyValueToSymbol(CUDA_Dg_block, &m);                             // NOTE: So far OK ********************************************
 
-	double* pa, * pg, * pal, * pco, * pdytemp, * pytemp;
-	double* pe_1, * pe_2, * pe_3, * pe0_1, * pe0_2, * pe0_3;
-	double* pjp_Scale, * pjp_dphp_1, * pjp_dphp_2, * pjp_dphp_3;
-	double* pde, * pde0;
+	double* pa, * pal, * pco, * pdytemp, * pytemp;
 
 	//err = cudaMalloc(&pa, CUDA_Grid_dim_precalc * (Numfac + 1) * sizeof(double));
 	//cudaMemcpyToSymbol(CUDA_Area, &pa, sizeof(pa));
@@ -873,8 +876,6 @@ int CUDAPrecalc(int cudadev, double freq_start, double freq_end, double freq_ste
 
 	//err = cudaMalloc(&pg, CUDA_Grid_dim_precalc * (Numfac + 1) * (n_coef + 1) * sizeof(double));
 	//err = cudaMemcpyToSymbol(CUDA_Dg, &pg, sizeof(pg));
-	safeCudaMalloc(pg, CUDA_Grid_dim_precalc * (Numfac + 1) * (n_coef + 1));
-	CopyPointerToSymbol(CUDA_Dg, pg);
 
 	//err = cudaMalloc(&pal, CUDA_Grid_dim_precalc * (lmfit + 1) * (lmfit + 1) * sizeof(double));
 	//err = cudaMalloc(&pco, CUDA_Grid_dim_precalc * (lmfit + 1) * (lmfit + 1) * sizeof(double));
@@ -895,42 +896,30 @@ int CUDAPrecalc(int cudadev, double freq_start, double freq_end, double freq_ste
 
 	safeCudaMalloc(pal, CUDA_Grid_dim_precalc * (lmfit + 1) * (lmfit + 1));
 	safeCudaMalloc(pco, CUDA_Grid_dim_precalc * (lmfit + 1) * (lmfit + 1));
-	safeCudaMalloc(pdytemp, CUDA_Grid_dim_precalc * (gl.maxLcPoints + 1) * (ma + 1));
+	safeCudaMalloc(pdytemp, CUDA_Grid_dim_precalc * (size_t)(gl.maxLcPoints + 1) * DYT_STRIDE);
 	safeCudaMalloc(pytemp, CUDA_Grid_dim_precalc * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pe_1, CUDA_Grid_dim_precalc * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pe_2, CUDA_Grid_dim_precalc * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pe_3, CUDA_Grid_dim_precalc * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pe0_1, CUDA_Grid_dim_precalc * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pe0_2, CUDA_Grid_dim_precalc * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pe0_3, CUDA_Grid_dim_precalc * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pjp_Scale, CUDA_Grid_dim_precalc * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pjp_dphp_1, CUDA_Grid_dim_precalc * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pjp_dphp_2, CUDA_Grid_dim_precalc * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pjp_dphp_3, CUDA_Grid_dim_precalc * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pde, CUDA_Grid_dim_precalc * (gl.maxLcPoints + 1) * 4 * 4);
-	safeCudaMalloc(pde0, CUDA_Grid_dim_precalc * (gl.maxLcPoints + 1) * 4 * 4);
 
 	for (m = 0; m < CUDA_Grid_dim_precalc; m++)
 	{
 		freq_context ps;
 		ps.Area = &pa[m * (Numfac + 1)];                            // 1st pointer
-		ps.Dg = &pg[m * (Numfac + 1) * (n_coef + 1)];               // 2nd...
+		ps.Dg = NULL; /* folded into Area/CUDA_Dsph, see bright.cu */ // 2nd...
 		ps.alpha = &pal[m * (lmfit + 1) * (lmfit + 1)];             // 3
 		ps.covar = &pco[m * (lmfit + 1) * (lmfit + 1)];             // 4
-		ps.dytemp = &pdytemp[m * (gl.maxLcPoints + 1) * (ma + 1)];  // 5
+		ps.dytemp = &pdytemp[m * (size_t)(gl.maxLcPoints + 1) * DYT_STRIDE]; // 5
 		ps.ytemp = &pytemp[m * (gl.maxLcPoints + 1)];               // 6
-		ps.e_1 = &pe_1[m * (gl.maxLcPoints + 1)];                   // 7
-		ps.e_2 = &pe_2[m * (gl.maxLcPoints + 1)];                   // 8
-		ps.e_3 = &pe_3[m * (gl.maxLcPoints + 1)];                   // 9
-		ps.e0_1 = &pe0_1[m * (gl.maxLcPoints + 1)];                 // 10
-		ps.e0_2 = &pe0_2[m * (gl.maxLcPoints + 1)];                 // 11
-		ps.e0_3 = &pe0_3[m * (gl.maxLcPoints + 1)];                 // 12
-		ps.jp_Scale = &pjp_Scale[m * (gl.maxLcPoints + 1)];         // 13
-		ps.jp_dphp_1 = &pjp_dphp_1[m * (gl.maxLcPoints + 1)];       // 14
-		ps.jp_dphp_2 = &pjp_dphp_2[m * (gl.maxLcPoints + 1)];       // 15
-		ps.jp_dphp_3 = &pjp_dphp_3[m * (gl.maxLcPoints + 1)];       // 16
-		ps.de = &pde[m * (gl.maxLcPoints + 1) * 4 * 4];             // 17
-		ps.de0 = &pde0[m * (gl.maxLcPoints + 1) * 4 * 4];           // 18
+		ps.e_1 = NULL;                                            // 7
+		ps.e_2 = NULL;                                            // 8
+		ps.e_3 = NULL;                                            // 9
+		ps.e0_1 = NULL;                                            // 10
+		ps.e0_2 = NULL;                                            // 11
+		ps.e0_3 = NULL;                                            // 12
+		ps.jp_Scale = NULL;                                            // 13
+		ps.jp_dphp_1 = NULL;                                            // 14
+		ps.jp_dphp_2 = NULL;                                            // 15
+		ps.jp_dphp_3 = NULL;                                            // 16
+		ps.de = NULL;                                            // 17
+		ps.de0 = NULL;                                            // 18
 
 		//freq_context* pt = &((freq_context*)pcc)[m];
 		freq_context* pt = &pcc[m];
@@ -980,25 +969,23 @@ int CUDAPrecalc(int cudadev, double freq_start, double freq_end, double freq_ste
 				CudaCalculateIter1Mrqcof1Start<<<CUDA_Grid_dim_precalc, CUDA_BLOCK_DIM>>>();
 				for (iC = 1; iC < gl.Lcurves; iC++)
 				{
-					CudaCalculateIter1Mrqcof1Matrix<<<CUDA_Grid_dim_precalc, CUDA_BLOCK_DIM>>>(gl.Lpoints[iC]);
-					CudaCalculateIter1Mrqcof1Curve1<<<CUDA_Grid_dim_precalc, CUDA_BLOCK_DIM>>>(gl.Inrel[iC], gl.Lpoints[iC]);
-					CudaCalculateIter1Mrqcof1Curve2<<<CUDA_Grid_dim_precalc, CUDA_BLOCK_DIM>>>(gl.Inrel[iC], gl.Lpoints[iC]);
+					CudaCalculateIter1Mrqcof1Curve1<<<CUDA_Grid_dim_precalc, 32>>>(gl.Inrel[iC], gl.Lpoints[iC]);
+					CudaCalculateIter1Mrqcof1Curve2<<<CUDA_Grid_dim_precalc, 32>>>(gl.Inrel[iC], gl.Lpoints[iC]);
 				}
-				CudaCalculateIter1Mrqcof1Curve1Last<<<CUDA_Grid_dim_precalc, CUDA_BLOCK_DIM>>>(gl.Inrel[gl.Lcurves], gl.Lpoints[gl.Lcurves]);
-				CudaCalculateIter1Mrqcof1Curve2<<<CUDA_Grid_dim_precalc, CUDA_BLOCK_DIM>>>(gl.Inrel[gl.Lcurves], gl.Lpoints[gl.Lcurves]);
+				CudaCalculateIter1Mrqcof1Curve1Last<<<CUDA_Grid_dim_precalc, 32>>>(gl.Inrel[gl.Lcurves], gl.Lpoints[gl.Lcurves]);
+				CudaCalculateIter1Mrqcof1Curve2<<<CUDA_Grid_dim_precalc, 32>>>(gl.Inrel[gl.Lcurves], gl.Lpoints[gl.Lcurves]);
 				CudaCalculateIter1Mrqcof1End<<<CUDA_Grid_dim_precalc, 1>>>();
 				//mrqcof
-				CudaCalculateIter1Mrqmin1End<<<CUDA_Grid_dim_precalc, CUDA_BLOCK_DIM>>>();
+				CudaCalculateIter1Mrqmin1End<<<CUDA_Grid_dim_precalc, CUDA_BLOCK_DIM, gaussShBytes>>>();
 				//mrqcof
 				CudaCalculateIter1Mrqcof2Start<<<CUDA_Grid_dim_precalc, CUDA_BLOCK_DIM>>>();
 				for (iC = 1; iC < gl.Lcurves; iC++)
 				{
-					CudaCalculateIter1Mrqcof2Matrix<<<CUDA_Grid_dim_precalc, CUDA_BLOCK_DIM>>>(gl.Lpoints[iC]);
-					CudaCalculateIter1Mrqcof2Curve1<<<CUDA_Grid_dim_precalc, CUDA_BLOCK_DIM>>>(gl.Inrel[iC], gl.Lpoints[iC]);
-					CudaCalculateIter1Mrqcof2Curve2<<<CUDA_Grid_dim_precalc, CUDA_BLOCK_DIM>>>(gl.Inrel[iC], gl.Lpoints[iC]);
+					CudaCalculateIter1Mrqcof2Curve1<<<CUDA_Grid_dim_precalc, 32>>>(gl.Inrel[iC], gl.Lpoints[iC]);
+					CudaCalculateIter1Mrqcof2Curve2<<<CUDA_Grid_dim_precalc, 32>>>(gl.Inrel[iC], gl.Lpoints[iC]);
 				}
-				CudaCalculateIter1Mrqcof2Curve1Last<<<CUDA_Grid_dim_precalc, CUDA_BLOCK_DIM>>>(gl.Inrel[gl.Lcurves], gl.Lpoints[gl.Lcurves]);
-				CudaCalculateIter1Mrqcof2Curve2<<<CUDA_Grid_dim_precalc, CUDA_BLOCK_DIM>>>(gl.Inrel[gl.Lcurves], gl.Lpoints[gl.Lcurves]);
+				CudaCalculateIter1Mrqcof2Curve1Last<<<CUDA_Grid_dim_precalc, 32>>>(gl.Inrel[gl.Lcurves], gl.Lpoints[gl.Lcurves]);
+				CudaCalculateIter1Mrqcof2Curve2<<<CUDA_Grid_dim_precalc, 32>>>(gl.Inrel[gl.Lcurves], gl.Lpoints[gl.Lcurves]);
 				CudaCalculateIter1Mrqcof2End<<<CUDA_Grid_dim_precalc, 1>>>();
 				//mrqcof
 				CudaCalculateIter1Mrqmin2End<<<CUDA_Grid_dim_precalc, 1>>>();
@@ -1070,20 +1057,7 @@ int CUDAPrecalc(int cudadev, double freq_start, double freq_end, double freq_ste
 	 * }
 	 */
 
-	cudaFree(pjp_Scale);
-	cudaFree(pjp_dphp_1);
-	cudaFree(pjp_dphp_2);
-	cudaFree(pjp_dphp_3);
-	cudaFree(pde);
-	cudaFree(pde0);
-	cudaFree(pe_1);
-	cudaFree(pe_2);
-	cudaFree(pe_3);
-	cudaFree(pe0_1);
-	cudaFree(pe0_2);
-	cudaFree(pe0_3);
 	cudaFree(pa);
-	cudaFree(pg);
 	cudaFree(pal);
 	cudaFree(pco);
 	cudaFree(pdytemp);
@@ -1225,6 +1199,12 @@ int CUDAStart(int cudadev, int n_start_from, double freq_start, double freq_end,
 	CopyValueToSymbol(CUDA_ma, &ma);
 	CopyValueToSymbol(CUDA_mfit, &lmfit);
 
+	if (ma > DYT_STRIDE - 1)
+	{
+		fprintf(stderr, "Error: ma = %d exceeds the supported maximum of %d parameters (spherical-harmonics degree > 6)\n", ma, DYT_STRIDE - 1);
+		exit(3);
+	}
+	const size_t gaussShBytes = ((size_t)(lmfit + 1) * ((lmfit + 1) | 1) + lmfit + 2) * sizeof(double);
 	m = lmfit + 1;
 	//cudaMemcpyToSymbol(CUDA_mfit1, &m, sizeof(m));
 	//cudaMemcpyToSymbol(CUDA_lastma, &llastma, sizeof(llastma));
@@ -1251,10 +1231,7 @@ int CUDAStart(int cudadev, int n_start_from, double freq_start, double freq_end,
 	//cudaMemcpyToSymbol(CUDA_Dg_block, &m, sizeof(m));
 	CopyValueToSymbol(CUDA_Dg_block, &m);
 
-	double* pa, * pg, * pal, * pco, * pdytemp, * pytemp;
-	double* pe_1, * pe_2, * pe_3, * pe0_1, * pe0_2, * pe0_3;
-	double* pjp_Scale, * pjp_dphp_1, * pjp_dphp_2, * pjp_dphp_3;
-	double* pde, * pde0;
+	double* pa, * pal, * pco, * pdytemp, * pytemp;
 
 	//err = cudaMalloc(&pa, CUDA_grid_dim * (Numfac + 1) * sizeof(double));
 	//err = cudaMemcpyToSymbol(CUDA_Area, &pa, sizeof(pa));
@@ -1263,8 +1240,6 @@ int CUDAStart(int cudadev, int n_start_from, double freq_start, double freq_end,
 
 	//err = cudaMalloc(&pg, CUDA_grid_dim * (Numfac + 1) * (n_coef + 1) * sizeof(double));
 	//err = cudaMemcpyToSymbol(CUDA_Dg, &pg, sizeof(pg));
-	safeCudaMalloc(pg, CUDA_grid_dim * (Numfac + 1) * (n_coef + 1));
-	CopyPointerToSymbol(CUDA_Dg, pg);
 
 	//err = cudaMalloc(&pal, CUDA_grid_dim * (lmfit + 1) * (lmfit + 1) * sizeof(double));
 	//err = cudaMalloc(&pco, CUDA_grid_dim * (lmfit + 1) * (lmfit + 1) * sizeof(double));
@@ -1284,42 +1259,30 @@ int CUDAStart(int cudadev, int n_start_from, double freq_start, double freq_end,
 	//err = cudaMalloc(&pde0, CUDA_grid_dim * (gl.maxLcPoints + 1) * 4 * 4 * sizeof(double));
 	safeCudaMalloc(pal, CUDA_grid_dim * (lmfit + 1) * (lmfit + 1));
 	safeCudaMalloc(pco, CUDA_grid_dim * (lmfit + 1) * (lmfit + 1));
-	safeCudaMalloc(pdytemp, CUDA_grid_dim * (gl.maxLcPoints + 1) * (ma + 1));
+	safeCudaMalloc(pdytemp, CUDA_grid_dim * (size_t)(gl.maxLcPoints + 1) * DYT_STRIDE);
 	safeCudaMalloc(pytemp, CUDA_grid_dim * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pe_1, CUDA_grid_dim * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pe_2, CUDA_grid_dim * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pe_3, CUDA_grid_dim * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pe0_1, CUDA_grid_dim * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pe0_2, CUDA_grid_dim * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pe0_3, CUDA_grid_dim * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pjp_Scale, CUDA_grid_dim * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pjp_dphp_1, CUDA_grid_dim * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pjp_dphp_2, CUDA_grid_dim * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pjp_dphp_3, CUDA_grid_dim * (gl.maxLcPoints + 1));
-	safeCudaMalloc(pde, CUDA_grid_dim * (gl.maxLcPoints + 1) * 4 * 4);
-	safeCudaMalloc(pde0, CUDA_grid_dim * (gl.maxLcPoints + 1) * 4 * 4);
 
 	for (m = 0; m < CUDA_grid_dim; m++)
 	{
 		freq_context ps;
 		ps.Area = &pa[m * (Numfac + 1)];
-		ps.Dg = &pg[m * (Numfac + 1) * (n_coef + 1)];
+		ps.Dg = NULL; /* folded into Area/CUDA_Dsph, see bright.cu */
 		ps.alpha = &pal[m * (lmfit + 1) * (lmfit + 1)];
 		ps.covar = &pco[m * (lmfit + 1) * (lmfit + 1)];
-		ps.dytemp = &pdytemp[m * (gl.maxLcPoints + 1) * (ma + 1)];
+		ps.dytemp = &pdytemp[m * (size_t)(gl.maxLcPoints + 1) * DYT_STRIDE];
 		ps.ytemp = &pytemp[m * (gl.maxLcPoints + 1)];
-		ps.e_1 = &pe_1[m * (gl.maxLcPoints + 1)];
-		ps.e_2 = &pe_2[m * (gl.maxLcPoints + 1)];
-		ps.e_3 = &pe_3[m * (gl.maxLcPoints + 1)];
-		ps.e0_1 = &pe0_1[m * (gl.maxLcPoints + 1)];
-		ps.e0_2 = &pe0_2[m * (gl.maxLcPoints + 1)];
-		ps.e0_3 = &pe0_3[m * (gl.maxLcPoints + 1)];
-		ps.jp_Scale = &pjp_Scale[m * (gl.maxLcPoints + 1)];
-		ps.jp_dphp_1 = &pjp_dphp_1[m * (gl.maxLcPoints + 1)];
-		ps.jp_dphp_2 = &pjp_dphp_2[m * (gl.maxLcPoints + 1)];
-		ps.jp_dphp_3 = &pjp_dphp_3[m * (gl.maxLcPoints + 1)];
-		ps.de = &pde[m * (gl.maxLcPoints + 1) * 4 * 4];              
-		ps.de0 = &pde0[m * (gl.maxLcPoints + 1) * 4 * 4];               
+		ps.e_1 = NULL;
+		ps.e_2 = NULL;
+		ps.e_3 = NULL;
+		ps.e0_1 = NULL;
+		ps.e0_2 = NULL;
+		ps.e0_3 = NULL;
+		ps.jp_Scale = NULL;
+		ps.jp_dphp_1 = NULL;
+		ps.jp_dphp_2 = NULL;
+		ps.jp_dphp_3 = NULL;
+		ps.de = NULL;
+		ps.de0 = NULL;
 
 		freq_context* pt = &pcc[m];
 		handleCudaError(cudaMemcpy(pt, &ps, sizeof(void*) * 18, cudaMemcpyHostToDevice), "cudaMemcpy", "pt");
@@ -1376,15 +1339,14 @@ int CUDAStart(int cudadev, int n_start_from, double freq_start, double freq_end,
 				CudaCalculateIter1Mrqcof1Start<<<CUDA_grid_dim, CUDA_BLOCK_DIM>>>();
 				for (iC = 1; iC < gl.Lcurves; iC++)
 				{
-					CudaCalculateIter1Mrqcof1Matrix<<<CUDA_grid_dim, CUDA_BLOCK_DIM>>>(gl.Lpoints[iC]);
-					CudaCalculateIter1Mrqcof1Curve1<<<CUDA_grid_dim, CUDA_BLOCK_DIM>>>(gl.Inrel[iC], gl.Lpoints[iC]);
-					CudaCalculateIter1Mrqcof1Curve2<<<CUDA_grid_dim, CUDA_BLOCK_DIM>>>(gl.Inrel[iC], gl.Lpoints[iC]);
+					CudaCalculateIter1Mrqcof1Curve1<<<CUDA_grid_dim, 32>>>(gl.Inrel[iC], gl.Lpoints[iC]);
+					CudaCalculateIter1Mrqcof1Curve2<<<CUDA_grid_dim, 32>>>(gl.Inrel[iC], gl.Lpoints[iC]);
 				}
-				CudaCalculateIter1Mrqcof1Curve1Last<<<CUDA_grid_dim, CUDA_BLOCK_DIM>>>(gl.Inrel[gl.Lcurves], gl.Lpoints[gl.Lcurves]);
-				CudaCalculateIter1Mrqcof1Curve2<<<CUDA_grid_dim, CUDA_BLOCK_DIM>>>(gl.Inrel[gl.Lcurves], gl.Lpoints[gl.Lcurves]);
+				CudaCalculateIter1Mrqcof1Curve1Last<<<CUDA_grid_dim, 32>>>(gl.Inrel[gl.Lcurves], gl.Lpoints[gl.Lcurves]);
+				CudaCalculateIter1Mrqcof1Curve2<<<CUDA_grid_dim, 32>>>(gl.Inrel[gl.Lcurves], gl.Lpoints[gl.Lcurves]);
 				CudaCalculateIter1Mrqcof1End<<<CUDA_grid_dim, 1>>>();
 				//mrqcof
-				CudaCalculateIter1Mrqmin1End<<<CUDA_grid_dim, CUDA_BLOCK_DIM>>>();
+				CudaCalculateIter1Mrqmin1End<<<CUDA_grid_dim, CUDA_BLOCK_DIM, gaussShBytes>>>();
 
 				/*if (!if_freq_measured && nvml_enabled && n == n_start_from && m == N_POLES)
 			  {
@@ -1395,12 +1357,11 @@ int CUDAStart(int cudadev, int n_start_from, double freq_start, double freq_end,
 				CudaCalculateIter1Mrqcof2Start<<<CUDA_grid_dim, CUDA_BLOCK_DIM>>>();
 				for (iC = 1; iC < gl.Lcurves; iC++)
 				{
-					CudaCalculateIter1Mrqcof2Matrix<<<CUDA_grid_dim, CUDA_BLOCK_DIM>>>(gl.Lpoints[iC]);
-					CudaCalculateIter1Mrqcof2Curve1<<<CUDA_grid_dim, CUDA_BLOCK_DIM>>>(gl.Inrel[iC], gl.Lpoints[iC]);
-					CudaCalculateIter1Mrqcof2Curve2<<<CUDA_grid_dim, CUDA_BLOCK_DIM>>>(gl.Inrel[iC], gl.Lpoints[iC]);
+					CudaCalculateIter1Mrqcof2Curve1<<<CUDA_grid_dim, 32>>>(gl.Inrel[iC], gl.Lpoints[iC]);
+					CudaCalculateIter1Mrqcof2Curve2<<<CUDA_grid_dim, 32>>>(gl.Inrel[iC], gl.Lpoints[iC]);
 				}
-				CudaCalculateIter1Mrqcof2Curve1Last<<<CUDA_grid_dim, CUDA_BLOCK_DIM>>>(gl.Inrel[gl.Lcurves], gl.Lpoints[gl.Lcurves]);
-				CudaCalculateIter1Mrqcof2Curve2<<<CUDA_grid_dim, CUDA_BLOCK_DIM>>>(gl.Inrel[gl.Lcurves], gl.Lpoints[gl.Lcurves]);
+				CudaCalculateIter1Mrqcof2Curve1Last<<<CUDA_grid_dim, 32>>>(gl.Inrel[gl.Lcurves], gl.Lpoints[gl.Lcurves]);
+				CudaCalculateIter1Mrqcof2Curve2<<<CUDA_grid_dim, 32>>>(gl.Inrel[gl.Lcurves], gl.Lpoints[gl.Lcurves]);
 				CudaCalculateIter1Mrqcof2End<<<CUDA_grid_dim, 1>>>();
 				//mrqcof
 				CudaCalculateIter1Mrqmin2End<<<CUDA_grid_dim, 1>>>();
@@ -1480,20 +1441,7 @@ int CUDAStart(int cudadev, int n_start_from, double freq_start, double freq_end,
 
 	printf("\n");
 
-	cudaFree(pjp_Scale);
-	cudaFree(pjp_dphp_1);
-	cudaFree(pjp_dphp_2);
-	cudaFree(pjp_dphp_3);
-	cudaFree(pde);
-	cudaFree(pde0);
-	cudaFree(pe_1);
-	cudaFree(pe_2);
-	cudaFree(pe_3);
-	cudaFree(pe0_1);
-	cudaFree(pe0_2);
-	cudaFree(pe0_3);
 	cudaFree(pa);
-	cudaFree(pg);
 	cudaFree(pal);
 	cudaFree(pco);
 	cudaFree(pdytemp);


### PR DESCRIPTION
## What

Restructures the CUDA hot path (bright / curve2 / gauss) around memory locality. Together with #92 (pole merge, which this PR is stacked on — its two commits appear here and it should merge first), a Tesla V100 goes from **204.7 s to 33.8 s (6.1×)** on a test workunit, with results at reference-level accuracy (details below). The physics/math is unchanged; what changes is where the data lives and how many times it crosses DRAM.

## Why the app was slow

Profiling the LM inner loop showed it almost entirely DRAM-bound on three per-block structures streamed for every data point of every iteration:

1. **`Dg`** — a ~116 KB per-block matrix, recomputed by `curv` every iteration and gathered facet-by-facet in `bright` (8-byte scattered reads over 1280 blocks = guaranteed cache thrash).
2. **`dytemp`** — written point-major, read parameter-major: every access pattern strided.
3. **`alpha`** — a full triangular read-modify-write sweep in global memory *per data point* in `MrqcofCurve2`, plus a global-memory Gauss-Jordan per iteration.

## The changes

**`Dg` is deleted, not optimized** (`curv.cu`, `bright.cu`). `curv` computes `Dg[i][k] = g_i * Dsph[i][k]` and `bright` consumes `dbr_i * Dg[i][k]` with `dbr_i = Darea_i * s`. Since `Area_i = Darea_i * g_i`:

```
dbr_i * Dg[i][k] == (Area_i * s) * Dsph[i][k]
```

so the per-facet weight absorbs `g_i` and every block gathers from the **one global, read-only, facet-major `CUDA_Dsph`** — which stays cache-resident for all blocks.

**`bright` runs one warp per (frequency, pole) block** (`bright.cu`), processing two points per sweep so each `Dsph` row load feeds both points' accumulators. Facet visibility runs lanes-across-facets and is compacted with warp ballots; the derivative mat-vec runs lanes-across-coefficients with coalesced reads. The former `matrix_neo` pre-pass is computed in-kernel (one lane per point, staged in shared memory), which **deletes the `de`/`de0`/`e_1..e0_3`/`jp_Scale`/`jp_dphp_*` per-point global buffers — ~360 MB on a 1280-block grid with 2000-point workunits.** `dytemp` is stored transposed (stride 64) so both its writers and readers are coalesced; this bounds `ma ≤ 63` (spherical-harmonics degree ≤ 6, i.e. every production workunit) and the host errors out clearly beyond it.

**Normal equations accumulate per 8-point tile** (`curve2_CUDA.cu`): dyda tiles are staged to shared memory (the relative-lightcurve renormalization folds into the staging, removing another full read+write pass over `dytemp`), and the triangular `alpha` update becomes a rank-8 update — one sweep per 8 points instead of per point. Both original index variants (`ia[1]!=0` and `ia[1]==0`, including the gated tail rows) are reproduced element for element.

**Gauss-Jordan solves in shared memory** (`gauss_errc.cu`): the damped matrix stages straight from `alpha`; `covar` is never written (it is rezeroed before mrqcof2 accumulates into it) and the classic routine's final column-unscramble is dead code here, so only `da` leaves the solver.

`conv()` is no longer called (`mrqcof_curve1_last` computes the regularization curve with the same fold) — left in place to keep the diff focused; happy to remove it in a follow-up.

## Performance (Tesla V100, CUDA 12.9, sm_70, 373-frequency workunit)

| stage | time | cumulative speedup |
|---|---|---|
| current `dev` | 204.7 s | — |
| + pole merge (#92) | 146.4 s | 1.40× |
| + this PR | **33.8 s** | **6.1×** |

## Accuracy

Floating-point summation order changes, so outputs are not bit-identical; they are compared against high-precision CPU (FMA) references of the same workunits, alongside the BOINC validator's tolerances:

| workunit | result lines | byte-identical to CPU ref | differing bins |
|---|---|---|---|
| 248_1 | 496 | **496 (all)** | — |
| 239_1 | 373 | 372 | 1 (validator-negligible) |
| 320_1 | 398 | 381 | 9 better / 7 worse, mean rel. rms +5.8e-6 |

i.e. unbiased rounding-level noise — the same relationship to the CPU reference that current `dev` has.

## Possible follow-ups (not in this PR)

- An FP32 mirror of `Dsph` for the derivative gather on 1:32/1:64-DP GeForce parts (measured worthwhile there, slightly negative on 1:2-DP parts, so it wants a `__CUDA_ARCH__` gate).
- Removing dead `conv()`/`Dg` remnants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVQbTnynekGBztfKeCdkGv