### PR TITLE
[opencl, build] msvc, windows fix

### DIFF
--- a/period_search_opencl_amd/period_search/VersionInfo.hpp
+++ b/period_search_opencl_amd/period_search/VersionInfo.hpp
@@ -3,6 +3,6 @@
 bool GetVersionInfo(int& major, int& minor, int& build, int& revision);
 #else
 #include "Windows.h"
-bool GetVersionInfo(LPCTSTR filename`, int& major, int& minor, int& build, int& revision);
+bool GetVersionInfo(LPCTSTR filename, int& major, int& minor, int& build, int& revision);
 #endif
 

--- a/period_search_opencl_amd/psopencl_vs2022.vcxproj
+++ b/period_search_opencl_amd/psopencl_vs2022.vcxproj
@@ -527,7 +527,6 @@
     <ClCompile Include="period_search\phasec.cpp" />
     <ClCompile Include="period_search\sphfunc.cpp" />
     <ClCompile Include="period_search\Start_OpenCl.cpp" />
-    <ClCompile Include="period_search\Start_OpenCl_c++.cpp" />
     <ClCompile Include="period_search\stdafx.cpp" />
     <ClCompile Include="period_search\trifac.cpp" />
     <ClCompile Include="period_search\VersionInfo.cpp" />

--- a/period_search_opencl_amd/psopencl_vs2022.vcxproj.filters
+++ b/period_search_opencl_amd/psopencl_vs2022.vcxproj.filters
@@ -73,9 +73,6 @@
     <ClCompile Include="period_search\binaries.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="period_search\Start_OpenCl_c++.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="period_search\cpp.hint" />


### PR DESCRIPTION
Fixes a typo and excludes Start_OpenCl_c++ from the solution