### PR TITLE
OpenCL: restore the scratch-buffer mfreq_context in GlobalsCL.h (lost in the #102 rebase)

### DIFF
--- a/period_search_opencl_amd/period_search/GlobalsCL.h
+++ b/period_search_opencl_amd/period_search/GlobalsCL.h
@@ -24,11 +24,12 @@ typedef struct mfreq_context
 	//double* ytemp;
 
 	double Area[MAX_N_FAC + 1];
-	double alpha[(MAX_N_PAR + 1) * (MAX_N_PAR + 1)];
-	double covar[(MAX_N_PAR + 1) * (MAX_N_PAR + 1)];
-	double dytemp[(POINTS_MAX + 1) * (MAX_N_PAR + 1)];
-	double ytemp[POINTS_MAX + 1];
-
+	/* The point- and fit-dimensioned work arrays (alpha, covar, dytemp,
+	   ytemp, jp_*, e_*, de, de0) live in a separate runtime-sized scratch
+	   buffer - one slice of freq_context.scrStride doubles per work-group,
+	   at the offsets recorded in freq_context - instead of compile-time
+	   worst-case arrays here. That cuts per-context memory ~6x (2.27 MB ->
+	   ~0.4 MB for typical workunits). */
 	double beta[MAX_N_PAR + 1];
 	double atry[MAX_N_PAR + 1];
 	double da[MAX_N_PAR + 1];


### PR DESCRIPTION
## What happened

The kernel-locality series (originally #96, merged as #101) moved all sixteen point- and fit-dimensioned work arrays out of the device-side `mfreq_context` into the runtime-sized scratch buffer — that is where the ~6× VRAM reduction comes from. #101 landed correctly.

Merging the stale `opencl-pole-grid` branch afterwards (#102) re-applied the older pole-grid commits on top. Everything in them was already upstream, so the only surviving content of `c2a624e` is its conflict leftover: **`GlobalsCL.h` got the four biggest work arrays back** (`alpha`, `covar`, `dytemp`, `ytemp` — 3.88 MB per context), while the rest of the file kept the #101 state (the twelve `jp_*`/`e_*`/`de`/`de0` arrays stay deleted, the scratch offsets in `freq_context` stay). The commit message even describes the pre-#101 "3/4 of total memory" budget. The header now matches neither the old nor the new layout.

## Impact

- **Shipped binaries are fine.** The runtime compiles the embedded kernel string in `kernels.cpp`, which still has the small struct, and the host-side struct in `Globals_OpenCl.h` was never touched — the scratch buffer, the ¼-of-device-memory budget, and the VRAM reduction are all active in current `dev` builds.
- **The kernel-regeneration path is poisoned.** `GlobalsCL.h` is the first file `regen_kernels.sh` concatenates into the kernel string. Regenerating from current `dev` bakes a ~3.9 MB/context device struct against the ~22 KB/context host allocation (`CUDA_MCC2` is sized with the host `sizeof(mfreq_context)`), so every work-group past the first indexes far out of bounds — the next person to edit any `.cl` file ships garbage results or crashes.

## Fix

Restore `GlobalsCL.h` byte-identical (blob `117d790`) to the version that was validated on-GPU in #101. One file, +6/−5 lines, no change to the embedded kernel string or any binary.

Verified by running `regen_kernels.sh` before and after: before, the regenerated `kernels.cpp` contains the worst-case arrays; after, it reproduces the shipped `kernels.cpp` except two pre-existing inert drifts that predate this fix and are unrelated to it — the `MAX_N_FPOINTS` define added to `constants.h` after the last restringify (unused in kernel code), and one whitespace difference. The loose `kernelSource.cl` at the repo root is also stale relative to `kernels.cpp` (it predates the `0 *` term cleanups); both drifts will fold in naturally the next time the kernels are regenerated and revalidated, so this PR deliberately leaves the generated files untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019M6xeFumxFZ5FCCBfsykJ3