### PR TITLE
include cstdint

### DIFF
--- a/period_search_optimization_simd/period_search/CpuInfo.cpp
+++ b/period_search_optimization_simd/period_search/CpuInfo.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 #include <iostream>
 #include <array>
+#include <cstdint>
 
 #include "Enums.h"
 #include "declarations.h"


### PR DESCRIPTION
since gcc 15, it must be included explicitelly
https://gcc.gnu.org/gcc-15/porting_to.html#header-dep-changes